### PR TITLE
ignore babelrc

### DIFF
--- a/packages/next-yak/loaders/cssloader.cjs
+++ b/packages/next-yak/loaders/cssloader.cjs
@@ -22,6 +22,7 @@ module.exports = async function cssLoader(source) {
   // parse source with babel
   const ast = babel.parseSync(source, {
     filename: this.resourcePath,
+    configFile: false,
     plugins: [
       [
         "@babel/plugin-syntax-typescript",

--- a/packages/next-yak/loaders/tsloader.cjs
+++ b/packages/next-yak/loaders/tsloader.cjs
@@ -35,6 +35,7 @@ module.exports = async function tsloader(source) {
   // parse source with babel
   const result = babel.transformSync(source, {
     filename: this.resourcePath,
+    configFile: false,
     // Only for parsing - will be removed once moved to a swc or babel plugin
     plugins: [
       [

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -2,6 +2,14 @@ import { FunctionComponent } from "react";
 import { CSSInterpolation, css } from "./cssLiteral";
 import React from "react";
 
+//
+// The `styled()` and `styled.` API
+//
+// The API design is inspired by styled-components:
+// https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/constructors/styled.tsx
+// https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/models/StyledComponent.ts
+//
+
 type HtmlTags = keyof JSX.IntrinsicElements;
 
 function StyledFactory <THtmlTag extends HtmlTags>(Component: THtmlTag): <TProps extends Record<string, unknown>>(
@@ -31,6 +39,19 @@ function StyledFactory (Component: string | FunctionComponent<any>) {
   };
 };
 
+/**
+ * The `styled` method works perfectly on all of your own or any third-party component, 
+ * as long as they attach the passed className prop to a DOM element.
+ * 
+ * @usage
+ * 
+ * ```tsx
+ * const StyledLink = styled(Link)`
+ *  color: #BF4F74;
+ *  font-weight: bold;
+ * `;
+ * ```
+ */
 export const styled = new Proxy(StyledFactory, {
   get(target, TagName) {
     if (typeof TagName !== "string") {


### PR DESCRIPTION
right now our loaders randomly pick up babel configs which might cause unexpected behaviour