### PR TITLE
move babel plugin to separate file

### DIFF
--- a/packages/next-yak/loaders/__tests__/tsloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/tsloader.test.ts
@@ -20,6 +20,12 @@ const loaderContext = {
   getOptions: () => ({
     configPath: "/some/special/path/config",
   }),
+  async: () => (err, result) => {
+    if (err) {
+      throw err;
+    }
+    return result;
+  }
 };
 
 describe("tsloader", () => {

--- a/packages/next-yak/loaders/babel-yak-plugin.cjs
+++ b/packages/next-yak/loaders/babel-yak-plugin.cjs
@@ -1,0 +1,223 @@
+/// @ts-check
+const babel = require("@babel/core");
+const quasiClassifier = require("./lib/quasiClassifier.cjs");
+const replaceQuasiExpressionTokens = require("./lib/replaceQuasiExpressionTokens.cjs");
+const murmurhash2_32_gc = require("./lib/hash.cjs");
+const { relative, resolve, basename } = require("path");
+
+/** @typedef {import("./babel-yak-plugin.d.ts").YakBabelPluginOptions} YakBabelPluginOptions */
+
+/**
+ * Babel plugin for typescript files that use yak,
+ * it replaces the css template literal with a call to the 'styled' function
+ *
+ * @param {babel} babel
+ * @param {YakBabelPluginOptions} options
+ * @returns {babel.PluginObj<import("@babel/core").PluginPass & {localVarNames: {css?: string, styled?: string}, isImportedInCurrentFile: boolean, classNameCount: number, varIndex: number}>}
+ */
+module.exports = function (babel, options) {
+  const { replaces } = options;
+  const rootContext = options.rootContext || process.cwd();
+  const { types: t } = babel;
+
+  /** @type {string | null} */
+  let hashedFile = null;
+
+  return {
+    name: "next-yak",
+    pre() {
+      // Initialize state variables
+      this.localVarNames = {
+        css: undefined,
+        styled: undefined,
+      };
+      this.isImportedInCurrentFile = false;
+      this.classNameCount = 0;
+      this.varIndex = 0;
+    },
+    visitor: {
+      /**
+       * @param {import("@babel/traverse").NodePath<import("@babel/types").ImportDeclaration>} path
+       * @param {babel.PluginPass & {localVarNames: {css?: string, styled?: string}, isImportedInCurrentFile: boolean, classNameCount: number, varIndex: number}} state
+       */
+      ImportDeclaration(path, state) {
+        const node = path.node;
+        if (node.source.value !== "next-yak") {
+          return;
+        }
+
+        const filePath = state.file.opts.filename;
+        if (!filePath) {
+            throw new Error("filePath is undefined");
+        }
+        const fileName = basename(filePath).replace(/\.tsx?/, "");
+
+        // Import 'yacijs' styles and assign to '__styleYak'
+        // use webpacks !=! syntax to pretend that the typescript file is actually a css-module
+        path.insertAfter(
+          t.importDeclaration(
+            [t.importDefaultSpecifier(t.identifier("__styleYak"))],
+            t.stringLiteral(
+              `./${fileName}.yak.module.css!=!./${fileName}?./${fileName}.yak.module.css`
+            )
+          )
+        );
+
+        // Process import specifiers
+        node.specifiers.forEach((specifier) => {
+          if (
+            !("imported" in specifier) ||
+            !specifier.imported ||
+            !t.isIdentifier(specifier.imported)
+          ) {
+            return;
+          }
+
+          const importSpecifier = /** @type {babel.types.Identifier} */ (
+            specifier.imported
+          );
+          const localSpecifier = specifier.local || importSpecifier;
+          if (
+            importSpecifier.name === "styled" ||
+            importSpecifier.name === "css"
+          ) {
+            this.localVarNames[importSpecifier.name] = localSpecifier.name;
+            this.isImportedInCurrentFile = true;
+          }
+        });
+      },
+      /**
+       * @param {import("@babel/traverse").NodePath<import("@babel/types").TaggedTemplateExpression>} path
+       * @param {babel.PluginPass & {localVarNames: {css?: string, styled?: string}, isImportedInCurrentFile: boolean, classNameCount: number, varIndex: number}} state
+       */
+      TaggedTemplateExpression(path, state) {
+        if (!this.isImportedInCurrentFile) {
+          return;
+        }
+        // Check if the tag name matches the imported 'css' or 'styled' variable
+        const tag = path.node.tag;
+
+        const isCssLiteral =
+          t.isIdentifier(tag) &&
+          /** @type {babel.types.Identifier} */ (tag).name ===
+            this.localVarNames.css;
+        const isStyledLiteral =
+          t.isMemberExpression(tag) &&
+          t.isIdentifier(
+            /** @type {babel.types.MemberExpression} */ (tag).object
+          ) &&
+          /** @type {babel.types.Identifier} */ (
+            /** @type {babel.types.MemberExpression} */ (tag).object
+          ).name === this.localVarNames.styled;
+        const isStyledCall =
+          t.isCallExpression(tag) &&
+          t.isIdentifier(
+            /** @type {babel.types.CallExpression} */ (tag).callee
+          ) &&
+          /** @type {babel.types.Identifier} */ (
+            /** @type {babel.types.CallExpression} */ (tag).callee
+          ).name === this.localVarNames.styled;
+
+        if (!isCssLiteral && !isStyledLiteral && !isStyledCall) {
+          return;
+        }
+
+        replaceQuasiExpressionTokens(path.node.quasi, replaces, t);
+
+        // Keep the same selector for all quasis belonging to the same css block
+        const classNameExpression = t.memberExpression(
+          t.identifier("__styleYak"),
+          t.identifier(`style${this.classNameCount++}`)
+        );
+
+        // Replace the tagged template expression with a call to the 'styled' function
+        const newArguments = new Set();
+        const quasis = path.node.quasi.quasis;
+        const quasiTypes = quasis.map((quasi) =>
+          quasiClassifier(quasi.value.raw)
+        );
+        const expressions = path.node.quasi.expressions;
+
+        let cssVariablesInlineStyle;
+
+        for (let i = 0; i < quasis.length; i++) {
+          if (quasiTypes[i].empty) {
+            const expression = expressions[i];
+            if (expression) {
+              newArguments.add(expression);
+            }
+            continue;
+          }
+
+          // create css class name reference as argument
+          // e.g. `font-size: 2rem; display: flex;` -> `__styleYak.style1`
+
+          // AutoGenerate a unique className
+          newArguments.add(classNameExpression);
+
+          let isMerging = false;
+          // loop over all quasis belonging to the same css block
+          while (i < quasis.length - 1) {
+            const type = quasiTypes[i];
+            // expressions after a partial css are converted into css variables
+            if (
+              type.partialStart ||
+              type.partialEnd ||
+              (isMerging && type.empty)
+            ) {
+              isMerging = true;
+              // expression: `x`
+              // { style: { --v0: x}}
+              const expression = expressions[i];
+              i++;
+              if (!expression) {
+                continue;
+              }
+              if (!cssVariablesInlineStyle) {
+                cssVariablesInlineStyle = t.objectExpression([]);
+              }
+
+              if (!hashedFile) {
+                const resourcePath = state.file.opts.filename;
+                if (!resourcePath) {
+                    throw new Error("resourcePath is undefined");
+                }
+                const relativePath = relative(rootContext, resolve(rootContext, resourcePath));
+                hashedFile = murmurhash2_32_gc(relativePath);
+              }
+
+              cssVariablesInlineStyle.properties.push(
+                t.objectProperty(
+                  t.stringLiteral(`--🦬${hashedFile}${this.varIndex++}`),
+                  /** @type {babel.types.Expression} */ (expression)
+                )
+              );
+            } else if (type.empty) {
+              // empty quasis can be ignored
+              // e.g. `transition: color ${duration} ${easing};`
+            } else {
+              if (expressions[i]) {
+                newArguments.add(expressions[i]);
+              }
+              break;
+            }
+          }
+        }
+
+        if (cssVariablesInlineStyle) {
+          newArguments.add(
+            t.objectExpression([
+              t.objectProperty(
+                t.stringLiteral(`style`),
+                cssVariablesInlineStyle
+              ),
+            ])
+          );
+        }
+
+        const styledCall = t.callExpression(tag, [...newArguments]);
+        path.replaceWith(styledCall);
+      },
+    },
+  };
+};

--- a/packages/next-yak/loaders/babel-yak-plugin.cjs
+++ b/packages/next-yak/loaders/babel-yak-plugin.cjs
@@ -8,8 +8,9 @@ const { relative, resolve, basename } = require("path");
 /** @typedef {import("./babel-yak-plugin.d.ts").YakBabelPluginOptions} YakBabelPluginOptions */
 
 /**
- * Babel plugin for typescript files that use yak,
- * it replaces the css template literal with a call to the 'styled' function
+ * Babel plugin for typescript files that use yak - it will do things:
+ * - inject the import to the css-module (with .yak.module.css extension)
+ * - replace the css template literal with styles from the css-module
  *
  * @param {babel} babel
  * @param {YakBabelPluginOptions} options

--- a/packages/next-yak/loaders/babel-yak-plugin.d.ts
+++ b/packages/next-yak/loaders/babel-yak-plugin.d.ts
@@ -1,0 +1,9 @@
+// babel-yak-plugin.d.ts
+import { PluginItem } from '@babel/core';
+
+export type YakBabelPluginOptions = {
+    replaces: Record<string, Record<string, string>>, 
+    rootContext?: string
+}
+
+export default function plugin(options: YakBabelPluginOptions): PluginItem;

--- a/packages/next-yak/loaders/tsloader.cjs
+++ b/packages/next-yak/loaders/tsloader.cjs
@@ -3,13 +3,13 @@ const babel = require("@babel/core");
 const { resolve } = require("path");
 
 /**
- * Loader for typescript files that use yacijs, it replaces the css template literal with a call to the 'styled' function
+ * Loader for typescript files that use yak, it replaces the css template literal with a call to the 'styled' function
  * @param {string} source
  * @this {any}
  * @returns {Promise<string | void>}
  */
 module.exports = async function tsloader(source) {
-  // ignore files if they don't use yacijs
+  // ignore files if they don't use yak
   if (!source.includes("next-yak")) {
     return source;
   }
@@ -25,11 +25,12 @@ module.exports = async function tsloader(source) {
     : {};
   const replaces = config.replaces || {};
   const { rootContext, resourcePath } = this;
-  // Parse source with babel and pass options to the Babel plugin
+  // Compile the typescript file with babel - this will:
+  // - inject the import to the css-module (with .yak.module.css extension)
+  // - replace the css template literal with styles from the css-module
   const result = babel.transformSync(source, {
     filename: resourcePath,
     configFile: false,
-    // Use the Babel plugin you created here and pass the required options
     plugins: [
       [
         "@babel/plugin-syntax-typescript",
@@ -44,7 +45,6 @@ module.exports = async function tsloader(source) {
       ],
     ],
   });
-
   if (!result?.code) {
     throw new Error("babel transform failed");
   }

--- a/packages/next-yak/loaders/tsloader.cjs
+++ b/packages/next-yak/loaders/tsloader.cjs
@@ -1,240 +1,56 @@
 /// @ts-check
-const path = require("path");
 const babel = require("@babel/core");
-const quasiClassifier = require("./lib/quasiClassifier.cjs");
-const replaceQuasiExpressionTokens = require("./lib/replaceQuasiExpressionTokens.cjs");
-const murmurhash2_32_gc = require("./lib/hash.cjs");
-const { relative, resolve } = require("path");
+const { resolve } = require("path");
 
 /**
  * Loader for typescript files that use yacijs, it replaces the css template literal with a call to the 'styled' function
  * @param {string} source
  * @this {any}
- * @returns {Promise<string>}
+ * @returns {Promise<string | void>}
  */
 module.exports = async function tsloader(source) {
   // ignore files if they don't use yacijs
   if (!source.includes("next-yak")) {
     return source;
   }
+  const callback = this.async();
 
   // Config for replacing tokens in css template literals
   // can be based on a typescript file
   const options = this.getOptions();
-  const config = options.configPath ? await this.importModule(resolve(this.rootContext, options.configPath), { 
-    layer: "yak-importModule",
-  }) : {};
+  const config = options.configPath
+    ? await this.importModule(resolve(this.rootContext, options.configPath), {
+        layer: "yak-importModule",
+      })
+    : {};
   const replaces = config.replaces || {};
-
-  /** @type {string | null} */
-  let hashedFile = null;
   const { rootContext, resourcePath } = this;
-
-  const { types: t } = babel;
-  const fileName = path.basename(this.resourcePath).replace(/\.tsx?/, "");
-  // parse source with babel
+  // Parse source with babel and pass options to the Babel plugin
   const result = babel.transformSync(source, {
-    filename: this.resourcePath,
+    filename: resourcePath,
     configFile: false,
-    // Only for parsing - will be removed once moved to a swc or babel plugin
+    // Use the Babel plugin you created here and pass the required options
     plugins: [
       [
         "@babel/plugin-syntax-typescript",
         { isTSX: this.resourcePath.endsWith(".tsx") },
       ],
-      /**
-       * @returns {import("@babel/core").PluginObj<import("@babel/core").PluginPass & {localVarNames: {css?: string, styled?: string}, isImportedInCurrentFile: boolean, classNameCount: number, varIndex: number}>}
-       */
-      function () {
-        return {
-          name: "next-yak",
-          pre() {
-            // Initialize state variables
-            this.localVarNames = {
-              css: undefined,
-              styled: undefined,
-            };
-            this.isImportedInCurrentFile = false;
-            this.classNameCount = 0;
-            this.varIndex = 0;
-          },
-          visitor: {
-            /**
-             * @param {import("@babel/traverse").NodePath<import("@babel/types").ImportDeclaration>} path
-             */
-            ImportDeclaration(path) {
-              const node = path.node;
-              if (
-                node.source.value !== "next-yak"
-              ) {
-                return;
-              }
-
-              // Import 'yacijs' styles and assign to '__styleYak'
-              // use webpacks !=! syntax to pretend that the typescript file is actually a css-module
-              path.insertAfter(
-                t.importDeclaration(
-                  [t.importDefaultSpecifier(t.identifier("__styleYak"))],
-                  t.stringLiteral(
-                    `./${fileName}.yak.module.css!=!./${fileName}?./${fileName}.yak.module.css`
-                  )
-                )
-              );
-
-              // Process import specifiers
-              node.specifiers.forEach((specifier) => {
-                if (
-                  !("imported" in specifier) ||
-                  !specifier.imported ||
-                  !t.isIdentifier(specifier.imported)
-                ) {
-                  return;
-                }
-
-                const importSpecifier = /** @type {babel.types.Identifier} */ (
-                  specifier.imported
-                );
-                const localSpecifier = specifier.local || importSpecifier;
-                if (
-                  importSpecifier.name === "styled" ||
-                  importSpecifier.name === "css"
-                ) {
-                  this.localVarNames[importSpecifier.name] =
-                    localSpecifier.name;
-                  this.isImportedInCurrentFile = true;
-                }
-              });
-            },
-            TaggedTemplateExpression(path) {
-              if (!this.isImportedInCurrentFile) {
-                return;
-              }
-              // Check if the tag name matches the imported 'css' or 'styled' variable
-              const tag = path.node.tag;
-
-              const isCssLiteral =
-                t.isIdentifier(tag) &&
-                /** @type {babel.types.Identifier} */ (tag).name ===
-                  this.localVarNames.css;
-              const isStyledLiteral =
-                t.isMemberExpression(tag) &&
-                t.isIdentifier(
-                  /** @type {babel.types.MemberExpression} */ (tag).object
-                ) &&
-                /** @type {babel.types.Identifier} */ (
-                  /** @type {babel.types.MemberExpression} */ (tag).object
-                ).name === this.localVarNames.styled;
-              const isStyledCall =
-                t.isCallExpression(tag) &&
-                t.isIdentifier(
-                  /** @type {babel.types.CallExpression} */ (tag).callee
-                ) &&
-                /** @type {babel.types.Identifier} */ (
-                  /** @type {babel.types.CallExpression} */ (tag).callee
-                ).name === this.localVarNames.styled;
-
-              if (!isCssLiteral && !isStyledLiteral && !isStyledCall) {
-                return;
-              }
-
-              replaceQuasiExpressionTokens(path.node.quasi, replaces, t);
-
-              // Keep the same selector for all quasis belonging to the same css block
-              const classNameExpression = t.memberExpression(
-                t.identifier("__styleYak"),
-                t.identifier(`style${this.classNameCount++}`)
-              );
-
-              // Replace the tagged template expression with a call to the 'styled' function
-              const newArguments = new Set();
-              const quasis = path.node.quasi.quasis;
-              const quasiTypes = quasis.map((quasi) =>
-                quasiClassifier(quasi.value.raw)
-              );
-              const expressions = path.node.quasi.expressions;
-
-              let cssVariablesInlineStyle;
-
-              for (let i = 0; i < quasis.length; i++) {
-                if (quasiTypes[i].empty) {
-                  const expression = expressions[i];
-                  if (expression) {
-                    newArguments.add(expression);
-                  }
-                  continue;
-                }
-
-                // create css class name reference as argument
-                // e.g. `font-size: 2rem; display: flex;` -> `__styleYak.style1`
-
-                // AutoGenerate a unique className
-                newArguments.add(classNameExpression);
-
-                let isMerging = false;
-                // loop over all quasis belonging to the same css block
-                while (i < quasis.length - 1) {
-                  const type = quasiTypes[i];
-                  // expressions after a partial css are converted into css variables
-                  if (
-                    type.partialStart ||
-                    type.partialEnd ||
-                    (isMerging && type.empty)
-                  ) {
-                    isMerging = true;
-                    // expression: `x`
-                    // { style: { --v0: x}}
-                    const expression = expressions[i];
-                    i++;
-                    if (!expression) {
-                      continue;
-                    }
-                    if (!cssVariablesInlineStyle) {
-                      cssVariablesInlineStyle = t.objectExpression([]);
-                    }
-
-                    if (!hashedFile) {
-                      const relativePath = relative(rootContext, resourcePath);
-                      hashedFile = murmurhash2_32_gc(relativePath);
-                    }
-
-                    cssVariablesInlineStyle.properties.push(
-                      t.objectProperty(
-                        t.stringLiteral(`--🦬${hashedFile}${this.varIndex++}`),
-                        expression
-                      )
-                    );
-                  } else if (type.empty) {
-                    // empty quasis can be ignored
-                    // e.g. `transition: color ${duration} ${easing};`
-                  } else {
-                    if (expressions[i]) {
-                      newArguments.add(expressions[i]);
-                    }
-                    break;
-                  }
-                }
-              }
-
-              if (cssVariablesInlineStyle) {
-                newArguments.add(
-                  t.objectExpression([
-                    t.objectProperty(
-                      t.stringLiteral(`style`),
-                      cssVariablesInlineStyle
-                    ),
-                  ])
-                );
-              }
-
-              const styledCall = t.callExpression(tag, [...newArguments]);
-              path.replaceWith(styledCall);
-            },
-          },
-        };
-      },
+      [
+        require.resolve("./babel-yak-plugin.cjs"), 
+        {
+          replaces,
+          rootContext,
+        },
+      ],
     ],
   });
 
-  const code = (result && result.code);
-  return code == null ? source : code;
+  if (!result?.code) {
+    throw new Error("babel transform failed");
+  }
+  return callback( 
+    null,
+    result.code,
+    result.map
+  )
 };

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -6,11 +6,13 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
-    "./withYak": "./loaders/withYak.cjs"
+    "./withYak": "./loaders/withYak.cjs",
+    "./babel": "./runtime/babel-yak-plugin.js"
   },
   "typesVersions": {
     "*": {
       "withYak": ["./loaders/withYak.d.ts"],
+      "babel": ["./runtime/babel-yak-plugin.d.ts"],
       "*": ["./runtime/index.d.ts"]
     }
   },


### PR DESCRIPTION
moving the babel plugin into a stand alone plugin allows to use it for jest.

right now it would NOT work as jest plugin because it is 1:1 version of the previous implementation.

to be useful in a jest / vite environment the plugin would require a flag which would:

- not inejct the import
- would not use the injected import but rather a string like "yak-styles"

we should also add a test in our example package