### PR TITLE
add square-bracket-support

### DIFF
--- a/packages/next-yak/loaders/__tests__/cssloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/cssloader.test.ts
@@ -289,6 +289,40 @@ const headline = css\`
     `);
   });
 
+  it("should replace breakpoint references with actual media queries when using square brackets", async () => {
+    expect(
+      await cssloader.call(
+        loaderContext,
+        `
+import { css } from "next-yak";
+import { queries } from '@/theme.yak';
+
+const headline = css\`
+  color: blue;
+  \${queries["sm"]} {
+    color: red;
+  }
+  transition: color \${duration} \${easing};
+  display: block;
+  \${css\`color: orange\`}
+  \`;
+`
+      )
+    ).toMatchInlineSnapshot(`
+      ".headline_0 {
+        color: blue;
+        @media (min-width: 640px) {
+          color: red;
+        }
+        transition: color var(--🦬18fi82j0) var(--🦬18fi82j1);
+        display: block;
+          &:where(.headline_1) {
+      color: orange
+          }
+      }"
+    `);
+  });
+
   it("should prevent double escaped chars", async () => {
     // in styled-components \\ is replaced with \
     // this test verifies that yak provides the same behavior

--- a/packages/next-yak/loaders/lib/replaceQuasiExpressionTokens.cjs
+++ b/packages/next-yak/loaders/lib/replaceQuasiExpressionTokens.cjs
@@ -25,7 +25,9 @@
  * @param {import("@babel/types")} t
  */
 module.exports = function replaceTokensInQuasiExpressions(quasi, replacer, t) {
-  for (let i = 0; i < quasi.expressions.length; i++) {
+  // Iterate over the expressions in reverse order
+  // so removing items won't affect the index of the next item
+  for (let i = quasi.expressions.length - 1; i >= 0; i--) {
     const expression = quasi.expressions[i];
     // find the value to replace the expression with
     const replacement = getReplacement(expression, replacer, t);
@@ -38,7 +40,6 @@ module.exports = function replaceTokensInQuasiExpressions(quasi, replacer, t) {
     );
     if (replacementValue !== false) {
       replaceExpressionAndMergeQuasis(quasi, i, replacementValue);
-      i--;
     } 
   }
 };

--- a/packages/next-yak/loaders/lib/replaceQuasiExpressionTokens.cjs
+++ b/packages/next-yak/loaders/lib/replaceQuasiExpressionTokens.cjs
@@ -29,19 +29,15 @@ module.exports = function replaceTokensInQuasiExpressions(quasi, replacer, t) {
     const expression = quasi.expressions[i];
     // find the value to replace the expression with
     const replacement = getReplacement(expression, replacer, t);
-    if (replacement === false) {
-      continue;
-    }
-    const replacementValue = getReplacementValueForExpression(
+    const replacementValue = replacement && getReplacementValueForExpression(
       expression,
       replacement,
       t
     );
-    if (replacementValue === false) {
-      continue;
-    }
-    replaceExpressionAndMergeQuasis(quasi, i, replacementValue);
-    i--;
+    if (replacementValue !== false) {
+      replaceExpressionAndMergeQuasis(quasi, i, replacementValue);
+      i--;
+    } 
   }
 };
 

--- a/packages/next-yak/loaders/lib/replaceQuasiExpressionTokens.cjs
+++ b/packages/next-yak/loaders/lib/replaceQuasiExpressionTokens.cjs
@@ -29,6 +29,8 @@ module.exports = function replaceTokensInQuasiExpressions(quasi, replacer, t) {
     const expression = quasi.expressions[i];
     // find the value to replace the expression with
     const replacement = getReplacement(expression, replacer, t);
+    // if it is a nested value, find the value of the expression
+    // e.g. x.y.z -> find the value of z
     const replacementValue = replacement && getReplacementValueForExpression(
       expression,
       replacement,

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-yak",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "types": "./dist/",
   "exports": {


### PR DESCRIPTION
we got a request to support numeric indexes for yak files e.g.:

```ts
import { spacings } from "./constants.yak";

const Button = styled.button`
   margin: ${spacings[0]}
`
```

this pr uses recursions to allow any combination of computed and uncomputed member expressions like for example:

`a.usage["of"][5].member.expressions`