### PR TITLE
Added transpilation of the css prop for simple cases

### DIFF
--- a/packages/example/app/page.tsx
+++ b/packages/example/app/page.tsx
@@ -117,6 +117,14 @@ export default function Home() {
     <YakThemeProvider>
       <main className={styles.main}>
         <Headline $primary>Hello world</Headline>
+        <h2
+          css={css`
+            font-size: 1.5rem;
+            font-weight: 400;
+          `}
+        >
+          Subheading
+        </h2>
         <Button>Ghost</Button>
         <Button $primary>Primary Ghost</Button>
         <FancyButton $primary title="fancy">

--- a/packages/next-yak/loaders/__tests__/cssloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/cssloader.test.ts
@@ -703,4 +703,69 @@ const headline = css\`
             }"
     `);
   });
+
+  it("should work with css property", async () => {
+    expect(
+        await cssloader.call(
+          loaderContext,
+          `
+      import { css, styled } from "next-yak";
+      const Elem = () =>  
+        <div css={css\`
+        padding: 10px;
+        \`} />
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        "._YakComp_0 {
+                padding: 10px;
+              }"
+      `);
+  })
+
+  it("should work with multiple components that use the css property", async () => {
+    expect(
+        await cssloader.call(
+          loaderContext,
+          `
+      import { css, styled } from "next-yak";
+      const Elem = () =>  
+        <div css={css\`
+        padding: 10px;
+        \`} />;
+      const OtherElem = () =>  
+        <div css={css\`
+        padding: 10px;
+        \`} />;
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        "._YakComp_0 {
+                padding: 10px;
+              }
+              ._YakComp2_1 {
+                padding: 10px;
+              }"
+      `);
+  })
+
+it("should work with when css property reuses css", async () => {
+    expect(
+        await cssloader.call(
+          loaderContext,
+          `
+      import { css, styled } from "next-yak";
+      const padding = css\`
+        padding: 10px;
+        \`; 
+      const Elem = () =>  
+        <div css={padding} />;
+        `
+        )
+      ).toMatchInlineSnapshot(`
+        ".padding_0 {
+                padding: 10px;
+              }"
+      `);
+  })
 });

--- a/packages/next-yak/loaders/__tests__/tsloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/tsloader.test.ts
@@ -920,4 +920,256 @@ const Button = styled.button\`
       });"
     `);
   });
+
+  it("should work with a simple css property", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css } from "next-yak";
+     const elem = <div css={css\`
+      padding: 10px;
+      \`} />
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const elem = <_YakComp />;
+      var _YakComp = styled(\\"div\\")(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("should work with a simple nested css property", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = () => <div><p><div css={css\`
+      padding: 10px;
+      \`}>anything</div></p></div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = () => <div><p><_YakComp>anything</_YakComp></p></div>;
+      var _YakComp = styled(\\"div\\")(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("should work with css that has properties", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = () => <div css={css\`
+      \${(props) => props.padding && css\`padding: 10px;\`}
+      \`} padding>anything</div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = () => <_YakComp padding>anything</_YakComp>;
+      var _YakComp = styled(\\"div\\")(css(__styleYak._YakComp_0, props => props.padding && css(__styleYak.propsPadding_1)));"
+    `);
+  });
+
+  it("should work with css that has properties before the css prop", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = () => <div padding css={css\`
+      \${(props) => props.padding && css\`padding: 10px;\`}
+      \`}>anything</div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = () => <_YakComp padding>anything</_YakComp>;
+      var _YakComp = styled(\\"div\\")(css(__styleYak._YakComp_0, props => props.padding && css(__styleYak.propsPadding_1)));"
+    `);
+  });
+
+  it("should work with css that has spreaded properties before the css prop", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = (p) => <div {...p} css={css\`
+          padding: 10px;
+      \`}>anything</div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = p => <_YakComp {...p}>anything</_YakComp>;
+      var _YakComp = styled(\\"div\\")(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("should work with css that is spreaded into another component", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = (p) => <div {...p} >anything</div>;
+     const MyComp2 = () => <MyComp css={css\`
+          padding: 10px;
+      \`} />
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = p => <div {...p}>anything</div>;
+      const MyComp2 = () => <_YakComp />;
+      var _YakComp = styled(MyComp)(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("should work with simple object identifier", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const TestObj = {
+      TestMem: (p) => <div {...p} >anything</div>,
+     }
+     const MyComp2 = () => <TestObj.TestMem css={css\`
+          padding: 10px;
+      \`} />
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const TestObj = {
+        TestMem: p => <div {...p}>anything</div>
+      };
+      const MyComp2 = () => <_YakComp />;
+      var _YakComp = styled(TestObj.TestMem)(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("should work with nested object identifier", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const test = {
+      nested: {
+        TestMem: (p) => <div {...p} >anything</div>,
+      }
+     }
+     const MyComp2 = () => <test.nested.TestMem css={css\`
+          padding: 10px;
+      \`} />
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const test = {
+        nested: {
+          TestMem: p => <div {...p}>anything</div>
+        }
+      };
+      const MyComp2 = () => <_YakComp />;
+      var _YakComp = styled(test.nested.TestMem)(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("should work with custom elements", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp2 = () => <custom-element css={css\`
+          padding: 10px;
+      \`} />
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp2 = () => <_YakComp />;
+      var _YakComp = styled(\\"custom-element\\")(css(__styleYak._YakComp_0));"
+    `);
+  });
+
+  it("shouldn't convert it when css prop is a simple string", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = () => <div css={\`
+        padding: 10px;
+      \`}>anything</div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = () => <div css={\`
+              padding: 10px;
+            \`}>anything</div>;"
+    `);
+  });
+
+  it("should convert it when css uses variables", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = () => <div css={css\`
+        padding: \${({$primary}) => $primary && "10px"};
+      \`} $primary>anything</div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = () => <_YakComp $primary>anything</_YakComp>;
+      var _YakComp = styled(\\"div\\")(css(__styleYak._YakComp_0, {
+        \\"style\\": {
+          \\"--\\\\uD83E\\\\uDDAC18fi82j0\\": ({
+            $primary
+          }) => $primary && \\"10px\\"
+        }
+      }));"
+    `);
+  });
+
+  it("should convert it when css property is conditionally applied", async () => {
+    expect(
+      await tsloader.call(
+        loaderContext,
+        `
+     import { css, styled } from "next-yak";
+     const MyComp = () => <div css={true && css\`
+        padding: 10px;
+      \`}>anything</div>
+      `
+      )
+    ).toMatchInlineSnapshot(`
+      "import { css, styled } from \\"next-yak\\";
+      import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
+      const MyComp = () => <div css={true && css(__styleYak.MyComp_0)}>anything</div>;"
+    `);
+  });
 });

--- a/packages/next-yak/loaders/babel-yak-plugin.cjs
+++ b/packages/next-yak/loaders/babel-yak-plugin.cjs
@@ -11,6 +11,7 @@ const {
   getConstantName,
   getConstantValues,
 } = require("./lib/getConstantValues.cjs");
+const transpileCssProp = require("./lib/transpileCssProp.cjs");
 
 /** @typedef {{replaces: Record<string, unknown>, rootContext?: string}} YakBabelPluginOptions */
 /** @typedef {{ css: string | undefined, styled: string | undefined, keyframes: string | undefined }} YakLocalIdentifierNames */
@@ -34,7 +35,8 @@ const {
  *     astNode: import("@babel/types").CallExpression
  *   }>
  *  yakImportPath?: import("@babel/core").NodePath<import("@babel/core").types.ImportDeclaration>
- *  runtimeInternalHelpers: Set<string>
+ *  runtimeInternalHelpers: Set<string>,
+ *  rootPath: import("@babel/core").NodePath<import("@babel/types").Program> | null
  * }>}
  */
 module.exports = function (babel, options) {
@@ -132,11 +134,13 @@ module.exports = function (babel, options) {
       this.variableNameToStyledCall = new Map();
       this.topLevelConstBindings = new Map();
       this.runtimeInternalHelpers = new Set();
+      this.rootPath = null;
     },
     visitor: {
       Program: {
         enter(path, state) {
           this.topLevelConstBindings = getConstantValues(path, t);
+          this.rootPath = path;
         },
         exit(path, state) {
           if (this.runtimeInternalHelpers.size && this.yakImportPath) {
@@ -149,6 +153,21 @@ module.exports = function (babel, options) {
             this.yakImportPath.insertAfter(newImport);
           }
         },
+      },
+
+      /**
+       * @param {import("@babel/core").NodePath<import("@babel/types").JSXElement>} path
+       * @param {babel.PluginPass & {localVarNames: YakLocalIdentifierNames, isImportedInCurrentFile: boolean, classNameCount: number, varIndex: number, rootPath: import("@babel/core").NodePath<import("@babel/types").Program> | null}} state
+       */
+      JSXElement(path, state) {
+        if (!state.rootPath) {
+          throw new Error("rootPath is undefined");
+        }
+
+        if (!this.isImportedInCurrentFile) {
+          return;
+        }
+        transpileCssProp(path, state.rootPath, t, this.localVarNames);
       },
       /**
        * Store the name of the imported 'css' and 'styled' variables e.g.:

--- a/packages/next-yak/loaders/cssloader.cjs
+++ b/packages/next-yak/loaders/cssloader.cjs
@@ -12,6 +12,7 @@ const {
   getConstantName,
   getConstantValues,
 } = require("./lib/getConstantValues.cjs");
+const transpileCssProp = require("./lib/transpileCssProp.cjs");
 
 /**
  * @typedef {{ selector: string, hasParent: boolean, quasiCode: Array<{ insideCssValue: boolean, code: string }>, cssPartExpressions: { [key: number]: CssPartExpression[]} }} CssPartExpression
@@ -93,9 +94,13 @@ module.exports = async function cssLoader(source) {
   /** @type {Map<string, number | string | null>} */
   let topLevelConstBindings = new Map();
 
+  /** @type {import("@babel/core").NodePath<import("@babel/types").Program> | null} */
+  let rootPath = null;
+
   babel.traverse(ast, {
     Program(path) {
       topLevelConstBindings = getConstantValues(path, t);
+      rootPath = path;
     },
     /**
      * @param {import("@babel/core").NodePath<import("@babel/types").ImportDeclaration>} path
@@ -127,6 +132,17 @@ module.exports = async function cssLoader(source) {
           localVarNames[importSpecifier.name] = localSpecifier.name;
         }
       });
+    },
+
+    /**
+     * @param {import("@babel/core").NodePath<import("@babel/types").JSXElement>} path
+     */
+    JSXElement(path) {
+      if (!rootPath) {
+        throw new Error("rootPath is undefined");
+      }
+
+      transpileCssProp(path, rootPath, t, localVarNames);
     },
     /**
      * @param {import("@babel/core").NodePath<import("@babel/types").TaggedTemplateExpression>} path

--- a/packages/next-yak/loaders/lib/transpileCssProp.cjs
+++ b/packages/next-yak/loaders/lib/transpileCssProp.cjs
@@ -1,0 +1,167 @@
+/** @typedef {{ css?: string, styled?: string, keyframes?: string }} YakLocalIdentifierNames */
+
+/**
+ * Change css attribute to a named styled component. e.g.
+ * @example
+ * const x = <div css={css`...`} />
+ * // will be transformed to
+ * const x = <NewComponent />
+ * var NewComponent = styled('div')(css`...`)
+ * @param {import("@babel/core").NodePath<import("@babel/types").JSXElement>} path
+ * @param {import("@babel/core").NodePath<import("@babel/types").Program>} rootPath
+ * @param {import("@babel/types")} t
+ * @param {YakLocalIdentifierNames} localVarNames
+ */
+function transpileCssProp(path, rootPath, t, localVarNames) {
+  const openingElement = path.node.openingElement;
+  const closingElement = path.node.closingElement;
+  const cssPropIndex = openingElement.attributes.findIndex(
+    (prop) =>
+      t.isJSXAttribute(prop) &&
+      t.isJSXIdentifier(prop.name) &&
+      prop.name.name === "css"
+  );
+  if (cssPropIndex === -1) {
+    return;
+  }
+
+  const cssProp = /** @type {import("@babel/types").JSXAttribute} */ (
+    openingElement.attributes[cssPropIndex]
+  );
+
+  if (!t.isJSXExpressionContainer(cssProp.value)) {
+    return;
+  }
+
+  const cssValue = cssProp.value.expression;
+
+  if (!t.isTaggedTemplateExpression(cssValue)) {
+    return;
+  }
+
+  const expressionType = getYakExpressionType(cssValue.tag, localVarNames, t);
+
+  // todo: should work with references to the css function
+  if (expressionType !== "cssLiteral") {
+    return;
+  }
+
+  if (t.isJSXNamespacedName(openingElement.name)) {
+    throw new Error("Namespaced JSX not supported");
+  }
+
+  // todo: cache the import declaration for "next-yak"
+  // if styled isn't imported, we need to access the module and import it
+  // e.g.: import {css} from "next-yak" -> import {css, styled} from "next-yak"
+  if (localVarNames.styled == null) {
+    const nextYakImport =
+      /** @type {import("@babel/types").ImportDeclaration | undefined}  */ (
+        rootPath.node.body.find((node) => {
+          return (
+            t.isImportDeclaration(node) && node.source.value === "next-yak"
+          );
+        })
+      );
+    if (nextYakImport) {
+      nextYakImport.specifiers.push(
+        t.importSpecifier(t.identifier("styled"), t.identifier("styled"))
+      );
+    }
+  }
+
+  openingElement.attributes.splice(cssPropIndex, 1);
+  const styledVar = path.scope.generateUidIdentifier("YakComp");
+  const styledDeclaration = t.variableDeclaration("var", [
+    t.variableDeclarator(
+      styledVar,
+      t.callExpression(
+        t.callExpression(t.identifier(localVarNames.styled ?? "styled"), [
+          t.isJSXIdentifier(openingElement.name)
+            ? /^\p{Lu}/u.test(openingElement.name.name)
+              ? t.identifier(openingElement.name.name)
+              : t.stringLiteral(openingElement.name.name)
+            : jsxMemberExpressionToMemberExpression(openingElement.name, t),
+        ]),
+        [cssValue]
+      )
+    ),
+  ]);
+
+  openingElement.name = t.jsxIdentifier(styledVar.name);
+  if (closingElement) {
+    closingElement.name = t.jsxIdentifier(styledVar.name);
+  }
+
+  rootPath.pushContainer("body", styledDeclaration);
+}
+
+/**
+ * Converts a JSXMemberExpression that can be deeply nested JSXMemberExpressions to a MemberExpression and every JSXIdentifier to an Identifier
+ * @param {import("@babel/types").JSXMemberExpression} jsxMemberExpression
+ * @param {import("@babel/types")} t
+ * @returns {import("@babel/types").MemberExpression}
+ */
+const jsxMemberExpressionToMemberExpression = (jsxMemberExpression, t) => {
+  const { object, property } = jsxMemberExpression;
+  if (t.isJSXMemberExpression(object)) {
+    return t.memberExpression(
+      jsxMemberExpressionToMemberExpression(object, t),
+      t.identifier(property.name)
+    );
+  }
+  return t.memberExpression(
+    t.identifier(object.name),
+    t.identifier(property.name)
+  );
+};
+
+/**
+ * Returns wether the given tag is matching a yak import
+ *
+ * e.g.:
+ * - css`...` -> cssLiteral
+ * - styled.div`...` -> styledLiteral
+ * - styled(Component)`...` -> styledCall
+ * - styled.div.attrs({})`...` -> attrsCall
+ * - keyframes`...` -> keyframesLiteral
+ *
+ * @param {babel.types.Expression} tag
+ * @param {YakLocalIdentifierNames} localVarNames
+ * @param {import("@babel/types")} t
+ * @returns {"cssLiteral" | "keyframesLiteral" | "styledLiteral" | "styledCall" | "attrsCall" | "unknown"}
+ */
+function getYakExpressionType(tag, localVarNames, t) {
+  if (t.isIdentifier(tag)) {
+    if (tag.name === localVarNames.css) {
+      return "cssLiteral";
+    }
+    if (tag.name === localVarNames.keyframes) {
+      return "keyframesLiteral";
+    }
+  }
+  if (
+    t.isMemberExpression(tag) &&
+    t.isIdentifier(tag.object) &&
+    tag.object.name === localVarNames.styled
+  ) {
+    return "styledLiteral";
+  }
+  if (
+    t.isCallExpression(tag) &&
+    t.isIdentifier(tag.callee) &&
+    tag.callee.name === localVarNames.styled
+  ) {
+    return "styledCall";
+  }
+  if (
+    t.isCallExpression(tag) &&
+    t.isMemberExpression(tag.callee) &&
+    t.isIdentifier(tag.callee.property) &&
+    tag.callee.property.name === "attrs"
+  ) {
+    return "attrsCall";
+  }
+  return "unknown";
+}
+
+module.exports = transpileCssProp;


### PR DESCRIPTION
Closes #77 

Add the possibility to use the css template function ` css`` ` inside a special css property:
```jsx
const MyComponent = () => 
  <div css={css`
    padding: 10px;
  `>Anything</div>
```

This example would get transpiled to:
```jsx
const MyComponent = () => 
  <_YakComp>Anything</_YakComp>

var _YakComp = styled("div")(css(__styleYak._YakComp_0))
```