### PR TITLE
Fix composition types

### DIFF
--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -78,7 +78,7 @@
     "jsdom": "^22.1.0",
     "react": "^18.2.0",
     "react-test-renderer": "^18.2.0",
-    "typescript": "5.1.6",
+    "typescript": "5.4.5",
     "vite": "^4.4.9",
     "vitest": "0.34.5",
     "tsup": "7.2.0"

--- a/packages/next-yak/runtime/__tests__/typeTest.tsx
+++ b/packages/next-yak/runtime/__tests__/typeTest.tsx
@@ -190,11 +190,15 @@ const CompositionOverridingAndMergingTest = () => {
       ${Child} {
         color: blue;
       }
-      color: ${({ $colorMe }) => ($colorMe ? `blue` : `red`)};
+      color: ${
+        // @ts-expect-error - should not allow props which have not been defined (like styled-components)
+        ({ $colorMe }) => ($colorMe ? `blue` : `red`)
+      };
     `;
 
     // Overriding with Child and Mixin should work
     const _ = (
+      // @ts-expect-error - should not allow props which have not been defined (like styled-components)
       <Parent $colorMe>
         <Child $child />
       </Parent>

--- a/packages/next-yak/runtime/__tests__/typeTest.tsx
+++ b/packages/next-yak/runtime/__tests__/typeTest.tsx
@@ -190,7 +190,7 @@ const CompositionOverridingAndMergingTest = () => {
       ${Child} {
         color: blue;
       }
-      color: ${({ $colorMe }) => $colorMe ? `blue` : `red`};
+      color: ${({ $colorMe }) => ($colorMe ? `blue` : `red`)};
     `;
 
     // Overriding with Child and Mixin should work

--- a/packages/next-yak/runtime/__tests__/typeTest.tsx
+++ b/packages/next-yak/runtime/__tests__/typeTest.tsx
@@ -166,14 +166,36 @@ const CompositionOverridingAndMergingTest = () => {
         color: blue;
       }
 
-      ${Mixin} {
-        color: blue;
-      }
+      ${Mixin};
     `;
 
     // Overriding with Child and Mixin should work
     const _ = (
       <Parent $mixin>
+        <Child $child />
+      </Parent>
+    );
+  };
+
+  const case3 = () => {
+    const Child = styled.div<{ $child: boolean }>`
+      ${({ $child }) =>
+        $child &&
+        css`
+          color: red;
+        `}
+    `;
+
+    const Parent = styled.div`
+      ${Child} {
+        color: blue;
+      }
+      color: ${({ $colorMe }) => $colorMe ? `blue` : `red`};
+    `;
+
+    // Overriding with Child and Mixin should work
+    const _ = (
+      <Parent $colorMe>
         <Child $child />
       </Parent>
     );

--- a/packages/next-yak/runtime/__tests__/typeTest.tsx
+++ b/packages/next-yak/runtime/__tests__/typeTest.tsx
@@ -123,3 +123,59 @@ const MergeTestErrors = () => {
       return null;
   }
 };
+
+const CompositionOverridingAndMergingTest = () => {
+  const case1 = () => {
+    const Child = styled.div<{ $child: boolean }>`
+      ${({ $child }) =>
+        $child &&
+        css`
+          color: red;
+        `}
+    `;
+
+    const Parent = styled.div`
+      ${Child} {
+        color: blue;
+      }
+    `;
+
+    // should not inherit component props of Child
+    const _ = (
+      <Parent>
+        <Child $child />
+      </Parent>
+    );
+  };
+
+  const case2 = () => {
+    const Child = styled.div<{ $child: boolean }>`
+      ${({ $child }) =>
+        $child &&
+        css`
+          color: red;
+        `}
+    `;
+
+    const Mixin = css<{ $mixin: boolean }>`
+      color: ${({ $mixin }) => ($mixin ? `blue` : `red`)};
+    `;
+
+    const Parent = styled.div<{ $mixin: boolean }>`
+      ${Child} {
+        color: blue;
+      }
+
+      ${Mixin} {
+        color: blue;
+      }
+    `;
+
+    // Overriding with Child and Mixin should work
+    const _ = (
+      <Parent $mixin>
+        <Child $child />
+      </Parent>
+    );
+  };
+};

--- a/packages/next-yak/runtime/cssLiteral.tsx
+++ b/packages/next-yak/runtime/cssLiteral.tsx
@@ -1,7 +1,7 @@
 import { CSSProperties } from "react";
 import type { YakTheme } from "./index.d.ts";
 
-type ComponentStyles<TProps = {}> = (props: TProps) => {
+type ComponentStyles<TProps> = (props: TProps) => {
   className: string;
   style?: {
     [key: string]: string;
@@ -13,7 +13,7 @@ export type StaticCSSProp = {
   style?: CSSProperties;
 };
 
-export type CSSInterpolation<TProps = {}> =
+export type CSSInterpolation<TProps> =
   | string
   | number
   | undefined
@@ -61,7 +61,9 @@ export function css<TProps = {}>(
   styles: TemplateStringsArray,
   ...values: CSSInterpolation<TProps & { theme: YakTheme }>[]
 ): ComponentStyles<TProps>;
-export function css(...args: Array<any>): StaticCSSProp | ComponentStyles {
+export function css<TProps>(
+  ...args: Array<any>
+): StaticCSSProp | ComponentStyles<TProps> {
   const classNames: string[] = [];
   const dynamicCssFunctions: PropsToClassNameFn[] = [];
   const style: Record<string, string> = {};

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -162,9 +162,16 @@ const yakStyled = <
  * Type for the proxy object returned by `styled` that allows to
  * access all html tags as properties.
  */
-type StyledLiteral<T> = <TCSSProps = {}>(
+type StyledLiteral<T> = <TCSSProps>(
   styles: TemplateStringsArray,
-  ...values: Array<CSSInterpolation<T & TCSSProps & { theme: YakTheme }>>
+  ...values: Array<
+    CSSInterpolation<
+      T &
+        // don't allow inference from types in the tagged template literal
+        // additional benefit is that destruction is now typed and provides hints
+        NoInfer<TCSSProps> & { theme: YakTheme }
+    >
+  >
 ) => FunctionComponent<TCSSProps & T> & {
   // type only identifier to allow targeting components
   // e.g. styled.svg`${Button}:hover & { fill: red; }`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       vocs:
         specifier: latest
-        version: 1.0.0-alpha.25(@types/react@18.2.78)(react-dom@18.2.0)(react@18.2.0)(rollup@4.14.2)(typescript@5.2.2)
+        version: 1.0.0-alpha.25(@types/react@18.2.78)(react-dom@18.2.0)(react@18.2.0)(rollup@4.14.2)(typescript@5.4.5)
 
   packages/example:
     dependencies:
@@ -160,10 +160,10 @@ importers:
         version: 18.2.0(react@18.2.0)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(typescript@5.1.6)
+        version: 7.2.0(typescript@5.4.5)
       typescript:
-        specifier: 5.1.6
-        version: 5.1.6
+        specifier: 5.4.5
+        version: 5.4.5
       vite:
         specifier: ^4.4.9
         version: 4.4.9(@types/node@20.4.5)
@@ -9018,11 +9018,11 @@ packages:
       shikiji: 0.10.0-beta.9
     dev: false
 
-  /shikiji-twoslash@0.10.0-beta.9(typescript@5.2.2):
+  /shikiji-twoslash@0.10.0-beta.9(typescript@5.4.5):
     resolution: {integrity: sha512-VZNysft2sky0I5p4xCwoJ4BN1VxtRrY+aBu20hYGbX5IetUZl0jDFtdpNC32GUUhOddx/gy0X/fSCoomv0FE2Q==}
     dependencies:
       shikiji-core: 0.10.0-beta.9
-      twoslash: 0.0.11(typescript@5.2.2)
+      twoslash: 0.0.11(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9536,42 +9536,6 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
-  /tsup@7.2.0(typescript@5.1.6):
-    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.2(esbuild@0.18.20)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.18.20
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.31)
-      resolve-from: 5.0.0
-      rollup: 3.29.3
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
   /tsup@7.2.0(typescript@5.2.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
@@ -9608,28 +9572,64 @@ packages:
       - ts-node
     dev: true
 
+  /tsup@7.2.0(typescript@5.4.5):
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.2(esbuild@0.18.20)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.18.20
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.1(postcss@8.4.31)
+      resolve-from: 5.0.0
+      rollup: 3.29.3
+      source-map: 0.8.0-beta.0
+      sucrase: 3.34.0
+      tree-kill: 1.2.2
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
     dev: true
 
-  /twoslash@0.0.11(typescript@5.2.2):
+  /twoslash@0.0.11(typescript@5.4.5):
     resolution: {integrity: sha512-XCxpr8Of+swV66Ox5aTqkozax6tFjJrfP0UZrGNaKlqHDyvY1gUNZE2lUqj9phyF4cKoo/LxzOhkQw7zBmRyVw==}
     peerDependencies:
       typescript: '*'
     dependencies:
       '@typescript/vfs': 1.5.0
-      typescript: 5.2.2
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /twoslash@0.0.12(typescript@5.2.2):
+  /twoslash@0.0.12(typescript@5.4.5):
     resolution: {integrity: sha512-WUNpv9NUt1cUMokCAy79Y5nozyJ2F8mPM9utsxrkwgVcHtqLpxFaCLJG9lAL18EMOjAlfMBrswTW26w5KZvMSQ==}
     peerDependencies:
       typescript: '*'
     dependencies:
       '@typescript/vfs': 1.5.0
-      typescript: 5.2.2
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9660,9 +9660,16 @@ packages:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: false
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10151,7 +10158,7 @@ packages:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
     dev: true
 
-  /vocs@1.0.0-alpha.25(@types/react@18.2.78)(react-dom@18.2.0)(react@18.2.0)(rollup@4.14.2)(typescript@5.2.2):
+  /vocs@1.0.0-alpha.25(@types/react@18.2.78)(react-dom@18.2.0)(react@18.2.0)(rollup@4.14.2)(typescript@5.4.5):
     resolution: {integrity: sha512-oqJh2XCjq1WI6g809YLPEAzeYBabLAvOxVZCvJwTmZpSxDlaD4XdDOUWefXNscg72/L98jp9DFwUB3G7p6IbFg==}
     hasBin: true
     peerDependencies:
@@ -10211,10 +10218,10 @@ packages:
       serve-static: 1.15.0
       shikiji: 0.10.0-beta.9
       shikiji-transformers: 0.10.0-beta.9
-      shikiji-twoslash: 0.10.0-beta.9(typescript@5.2.2)
+      shikiji-twoslash: 0.10.0-beta.9(typescript@5.4.5)
       tailwindcss: 3.4.1
       toml: 3.0.0
-      twoslash: 0.0.12(typescript@5.2.2)
+      twoslash: 0.0.12(typescript@5.4.5)
       ua-parser-js: 1.0.37
       unified: 11.0.4
       unist-util-visit: 5.0.0


### PR DESCRIPTION
Fixes #72 

Use `NoInfer<T>` in order to be explicit for the tagged template literal types and not inferring them from the functions that are used for dynamic props or child components.

Added bonus: The destructuring of the props in the tagged template literal gives you now type hints, as TypeScript doesn't want to infer it dynamically and the type is known when you start with the literal.