### PR TITLE
Feature/fix stackblitz

### DIFF
--- a/packages/next-yak/cssloader.js
+++ b/packages/next-yak/cssloader.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/loader/cssloader.cjs");

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -34,6 +34,12 @@
         "require": "./dist/context/index.cjs"
       }
     },
+    "./tsloader.js": {
+      "require": "./dist/loaders/tsloader.cjs"
+    },
+    "./cssloader.js": {
+      "require": "./dist/loaders/cssloader.cjs"
+    },
     "./jsx-runtime": {
       "require": "./dist/jsx-runtime.cjs",
       "import": "./dist/jsx-runtime.js"

--- a/packages/next-yak/tsloader.js
+++ b/packages/next-yak/tsloader.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/loader/tsloader.cjs");

--- a/packages/next-yak/tsup.config.ts
+++ b/packages/next-yak/tsup.config.ts
@@ -98,7 +98,7 @@ export default defineConfig([
       "loaders/ts-loader.ts",
       "loaders/css-loader.ts",
     ],
-    format: ["esm", "cjs"],
+    format: ["cjs"],
     minify: false,
     sourcemap: true,
     clean: false,
@@ -113,7 +113,6 @@ export default defineConfig([
     target: "es2022",
     outDir: "dist/loaders",
   },
-
   // jsx-runtime
   {
     entryPoints: ["runtime/jsx-runtime.ts"],

--- a/packages/next-yak/withYak/index.ts
+++ b/packages/next-yak/withYak/index.ts
@@ -39,7 +39,7 @@ const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
       },
       use: [
         {
-          loader: path.join(currentDir, "../loaders/ts-loader.js"),
+          loader: path.join(currentDir, "../loaders/ts-loader.cjs"),
           options: yakOptions,
         },
       ],
@@ -47,7 +47,7 @@ const addYak = (yakOptions: YakConfigOptions, nextConfig: NextConfig) => {
 
     webpackConfig.module.rules.push({
       test: /\.yak\.module\.css$/,
-      loader: path.join(currentDir, "../loaders/css-loader.js"),
+      loader: path.join(currentDir, "../loaders/css-loader.cjs"),
       options: yakOptions,
     });
 


### PR DESCRIPTION
follow up for #108

once cssloader does not import tsloader we can switch from mjs to cjs

this might fix a incompatibility with stackblitz (https://github.com/stackblitz/webcontainer-core/issues/1478)