### PR TITLE
Fix comments issue

### DIFF
--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -386,7 +386,7 @@ where
 
       // Replace the quasi with "EXTRACTED"
       n.tpl = Box::new(Tpl {
-        span: DUMMY_SP,
+        span: n.tpl.span,
         exprs: vec![],
         quasis: vec![TplElement {
           span: DUMMY_SP,

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file/output.tsx
@@ -3,6 +3,6 @@ import { styled, css, keyframes } from "next-yak";
 // @ts-ignore
 import { Icon } from "./Icon";
 const primary = "green";
-const Button = styled.button`Button`;
-const Animation = keyframes`Animation`;
-const Wrapper = styled.div`Wrapper`;
+const Button = styled.button/*EXTRACTED*/ `Button`;
+const Animation = keyframes/*EXTRACTED*/ `Animation`;
+const Wrapper = styled.div/*EXTRACTED*/ `Wrapper`;


### PR DESCRIPTION
Comments are attached to `BytePos`, so you should not replace the span of the node with `DUMMY_SP` afterwards