### PR TITLE
merge both internal exports into one

### DIFF
--- a/packages/next-yak/loaders/__tests__/tsloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/tsloader.test.ts
@@ -1230,8 +1230,7 @@ const Button = styled.button\`
       ),
     ).toMatchInlineSnapshot(`
       "import styles from \\"./page.module.css\\";
-      import { css } from \\"next-yak/internal\\";
-      import { __yak_unitPostFix } from \\"next-yak/runtime-internals\\";
+      import { css, __yak_unitPostFix } from \\"next-yak/internal\\";
       import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
       const case1 =
       /*YAK Extracted CSS:
@@ -1629,8 +1628,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = () => <div {...__yak_mergeCssProp({
           className: \\"foo\\"
@@ -1655,8 +1653,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = () => <div {...__yak_mergeCssProp({
           style: {
@@ -1683,8 +1680,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = () => <div {...__yak_mergeCssProp({
           className: \\"foo\\"
@@ -1709,8 +1705,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = () => <div {...__yak_mergeCssProp({
           className: \\"foo\\",
@@ -1738,8 +1733,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = () => <div {...__yak_mergeCssProp({
           className: \\"foo\\",
@@ -1770,8 +1764,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = props => <div {...__yak_mergeCssProp(props,
         /*YAK Extracted CSS:
@@ -1795,8 +1788,7 @@ describe("css prop", () => {
       `,
         ),
       ).toMatchInlineSnapshot(`
-        "import { css, styled } from \\"next-yak/internal\\";
-        import { __yak_mergeCssProp } from \\"next-yak/runtime-internals\\";
+        "import { css, styled, __yak_mergeCssProp } from \\"next-yak/internal\\";
         import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
         const Elem = props => <div {...__yak_mergeCssProp(props,
         /*YAK Extracted CSS:

--- a/packages/next-yak/loaders/babel-yak-plugin.ts
+++ b/packages/next-yak/loaders/babel-yak-plugin.ts
@@ -209,15 +209,14 @@ export default function (
             },
           );
 
-          // Add used runtime helpers to the import
-          if (this.runtimeInternalHelpers.size && this.yakImportPath) {
-            const newImport = t.importDeclaration(
-              [...this.runtimeInternalHelpers].map((helper) =>
+          // Add all runtime helpers to the yak import path
+          const yakImportPath = this.yakImportPath;
+          if (this.runtimeInternalHelpers.size && yakImportPath) {
+            this.runtimeInternalHelpers.forEach((helper) => {
+              yakImportPath.node.specifiers.push(
                 t.importSpecifier(t.identifier(helper), t.identifier(helper)),
-              ),
-              t.stringLiteral("next-yak/runtime-internals"),
-            );
-            this.yakImportPath.insertAfter(newImport);
+              );
+            });
           }
         },
       },

--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -29,10 +29,6 @@
       "import": "./dist/static/index.js",
       "require": "./dist/static/index.cjs"
     },
-    "./runtime-internals": {
-      "import": "./dist/runtime-internals/index.js",
-      "require": "./dist/runtime-internals/index.cjs"
-    },
     "./internal": {
       "import": "./dist/internal.js",
       "require": "./dist/internal.cjs"

--- a/packages/next-yak/runtime/internal.ts
+++ b/packages/next-yak/runtime/internal.ts
@@ -32,7 +32,6 @@ export { keyframes } from "./keyframes.js";
 // to another file for classic react components
 export { useTheme, YakThemeProvider } from "next-yak/context";
 
-
 // runtime internals (helpers which get injected by the compiler)
 export { unitPostFix as __yak_unitPostFix } from "./internals/unitPostFix.js";
 export { mergeCssProp as __yak_mergeCssProp } from "./internals/mergeCssProp.js";

--- a/packages/next-yak/runtime/internal.ts
+++ b/packages/next-yak/runtime/internal.ts
@@ -31,3 +31,8 @@ export { keyframes } from "./keyframes.js";
 // links to one file for react server components and
 // to another file for classic react components
 export { useTheme, YakThemeProvider } from "next-yak/context";
+
+
+// runtime internals (helpers which get injected by the compiler)
+export { unitPostFix as __yak_unitPostFix } from "./internals/unitPostFix.js";
+export { mergeCssProp as __yak_mergeCssProp } from "./internals/mergeCssProp.js";

--- a/packages/next-yak/runtime/internals/index.ts
+++ b/packages/next-yak/runtime/internals/index.ts
@@ -1,2 +1,0 @@
-export { unitPostFix as __yak_unitPostFix } from "./unitPostFix.js";
-export { mergeCssProp as __yak_mergeCssProp } from "./mergeCssProp.js";

--- a/packages/next-yak/tsup.config.ts
+++ b/packages/next-yak/tsup.config.ts
@@ -34,17 +34,6 @@ export default defineConfig([
     target: "es2022",
     outDir: "dist",
   },
-  // runtime internals (helpers which get injected by the compiler)
-  {
-    entryPoints: ["runtime/internals/index.ts"],
-    format: ["cjs", "esm"],
-    minify: true,
-    sourcemap: true,
-    clean: true,
-    external: ["react"],
-    target: "es2022",
-    outDir: "dist/runtime-internals",
-  },
   // static
   {
     entryPoints: ["static/index.ts"],


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Refactor**
  - Move exports from `next-yak/runtime-internals` into `next-yak/internal` (and drop `next-yak/runtime-internals`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->