### PR TITLE
improve css-variable naming readability (same as the rust swc version)

### DIFF
--- a/packages/next-yak/loaders/__tests__/cssloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/cssloader.test.ts
@@ -113,7 +113,7 @@ const headline = css\`
       }
       .headline {
         &:hover {
-          color: var(--headline-color_18fi82j);
+          color: var(--headline__color_18fi82j);
         }
       }"
     `);
@@ -159,7 +159,7 @@ const headline = css\`
     ).toMatchInlineSnapshot(`
       ".headline {
         &:hover {
-          color: var(--headline-color_18fi82j);
+          color: var(--headline__color_18fi82j);
         }
       }"
     `);
@@ -227,7 +227,7 @@ const headline = css\`
       ),
     ).toMatchInlineSnapshot(`
       ".headline {
-        transition: color var(--headline-transition_18fi82j) var(--headline-transition_18fi82j_1);
+        transition: color var(--headline__transition_18fi82j) var(--headline__transition_18fi82j_1);
         display: block;
       }
       .headline__headline {
@@ -260,7 +260,7 @@ const headline = css\`
         @media (min-width: 640px) {
           color: red;
         }
-        transition: color var(--headline-transition_18fi82j) var(--headline-transition_18fi82j_1);
+        transition: color var(--headline__transition_18fi82j) var(--headline__transition_18fi82j_1);
         display: block;
       }
       .headline__headline {
@@ -293,7 +293,7 @@ const headline = css\`
         @media (min-width: 640px) {
           color: red;
         }
-        transition: color var(--headline-transition_18fi82j) var(--headline-transition_18fi82j_1);
+        transition: color var(--headline__transition_18fi82j) var(--headline__transition_18fi82j_1);
         display: block;
       }
       .headline__headline {
@@ -326,7 +326,7 @@ const headline = css\`
         @media (min-width: 640px) {
           color: red;
         }
-        transition: color var(--headline-transition_18fi82j) var(--headline-transition_18fi82j_1);
+        transition: color var(--headline__transition_18fi82j) var(--headline__transition_18fi82j_1);
         display: block;
       }
       .headline__headline {
@@ -609,7 +609,7 @@ const Component = styled.div\`
         background-color: blue;
       }
       .Component__not_active {
-        background-color: var(--Component__not_active-background-color_18fi82j);
+        background-color: var(--Component__not_active__background-color_18fi82j);
       }
       .Component {
         border: 1px solid black;
@@ -618,7 +618,7 @@ const Component = styled.div\`
         color: orange;
       }
       .Component__not_active_1 {
-        transition: color var(--Component__not_active_1-transition_18fi82j) var(--Component__not_active_1-transition_18fi82j_1);
+        transition: color var(--Component__not_active_1__transition_18fi82j) var(--Component__not_active_1__transition_18fi82j_1);
       }"
     `);
   });
@@ -669,9 +669,9 @@ const headline = css\`
       ),
     ).toMatchInlineSnapshot(`
       ".case3 {
-        padding: var(--case3-padding_18fi82j);
-        transform: translate(-50%, -50%) rotate(var(--case3-transform_18fi82j))
-      translate(0, -88px) rotate(var(--case3-transform_18fi82j_1));
+        padding: var(--case3__padding_18fi82j);
+        transform: translate(-50%, -50%) rotate(var(--case3__transform_18fi82j))
+      translate(0, -88px) rotate(var(--case3__transform_18fi82j_1));
       }"
     `);
   });
@@ -694,10 +694,10 @@ const headline = css\`
       ),
     ).toMatchInlineSnapshot(`
       ".case3 {
-        margin: var(--case3-margin_18fi82j);
-        top: var(--case3-top_18fi82j);
-        bottom: var(--case3-bottom_18fi82j);
-        left: var(--case3-left_18fi82j);
+        margin: var(--case3__margin_18fi82j);
+        top: var(--case3__top_18fi82j);
+        bottom: var(--case3__bottom_18fi82j);
+        left: var(--case3__left_18fi82j);
         right: 10px;
       }"
     `);
@@ -723,7 +723,7 @@ it("should allow allow using an inline nested css literal", async () => {
     ),
   ).toMatchInlineSnapshot(`
     ".Icon {}
-    .Button__primary {
+    .Button__$primary {
       &:has(.Icon) {
         color: red;
       }

--- a/packages/next-yak/loaders/__tests__/getCssName.test.ts
+++ b/packages/next-yak/loaders/__tests__/getCssName.test.ts
@@ -27,25 +27,25 @@ describe("getCssName", () => {
   it("should guess the css name from the condition of a logical expression", () => {
     const literal = getCssLiteral(`({$active}) => $active && css\`\``);
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active");
+    expect(cssName).toBe("$active");
   });
 
   it("should guess the css name from the condition of a ternary expression", () => {
     const literal = getCssLiteral(`({$active}) => $active ? css\`\` : null`);
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active");
+    expect(cssName).toBe("$active");
   });
 
   it("should guess the css name from the condition of a logical expression with negation", () => {
     const literal = getCssLiteral(`({$active}) => !$active && css\`\``);
     const cssName = getCssName(literal);
-    expect(cssName).toBe("not_active");
+    expect(cssName).toBe("not_$active");
   });
 
   it("should guess the css name from the condition of a ternary expression for the else case", () => {
     const literal = getCssLiteral(`({$active}) => $active ? null : css\`\``);
     const cssName = getCssName(literal);
-    expect(cssName).toBe("not_active");
+    expect(cssName).toBe("not_$active");
   });
 
   it("should guess the css name from the condition of a logical expression with multiple conditions", () => {
@@ -53,7 +53,7 @@ describe("getCssName", () => {
       `({$active, $visible}) => $active && $visible && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_and_visible");
+    expect(cssName).toBe("$active_and_$visible");
   });
 
   it("should guess the css name from the condition of a ternary expression with multiple conditions", () => {
@@ -61,7 +61,7 @@ describe("getCssName", () => {
       `({$active, $visible}) => $active ? ($visible ? css\`\` : null) : null`,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_and_visible");
+    expect(cssName).toBe("$active_and_$visible");
   });
 
   it("should guess the css name from the condition of a logical expression with negation and multiple conditions", () => {
@@ -69,7 +69,7 @@ describe("getCssName", () => {
       `({$active, $visible}) => !$active && $visible && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("not_active_and_visible");
+    expect(cssName).toBe("not_$active_and_$visible");
   });
 
   it("should guess the css name from the condition of a ternary expression with negation and multiple conditions", () => {
@@ -77,7 +77,7 @@ describe("getCssName", () => {
       `({$active, $visible}) => !$active ? ($visible ? css\`\`: null) : null`,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("not_active_and_visible");
+    expect(cssName).toBe("not_$active_and_$visible");
   });
 
   it("should guess the css name from the condition of a logical expression with negation and multiple conditions for the else case", () => {
@@ -85,7 +85,7 @@ describe("getCssName", () => {
       `({$active, $visible}) => $active && !$visible && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_and_not_visible");
+    expect(cssName).toBe("$active_and_not_$visible");
   });
 
   it("should guess the css name from the condition of a ternary expression with negation and multiple conditions for the else case", () => {
@@ -93,7 +93,7 @@ describe("getCssName", () => {
       `({$active, $visible}) => $active ? ($visible ? null : css\`\`) : null`,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_and_not_visible");
+    expect(cssName).toBe("$active_and_not_$visible");
   });
 
   it("should guess the css name from the condition of a nested logical expression", () => {
@@ -101,7 +101,7 @@ describe("getCssName", () => {
       `({ $visible }) => $visible && (({ $active }) => $active && css\`\`)`,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("visible_and_active");
+    expect(cssName).toBe("$visible_and_$active");
   });
 
   it("should guess the css name from a complex expression using AND and OR operators", () => {
@@ -109,7 +109,7 @@ describe("getCssName", () => {
       `({$active, $visible, $enabled}) => ($active || $visible) && $enabled && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_or_visible_and_enabled");
+    expect(cssName).toBe("$active_or_$visible_and_$enabled");
   });
 
   it("should guess the css name from nested logical expressions", () => {
@@ -117,7 +117,7 @@ describe("getCssName", () => {
       `({$active, $visible, $enabled}) => ($active && ($visible || $enabled)) && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_and_visible_or_enabled");
+    expect(cssName).toBe("$active_and_$visible_or_$enabled");
   });
 
   it("should guess the css name from an expression with multiple OR conditions", () => {
@@ -125,7 +125,7 @@ describe("getCssName", () => {
       `({$active, $visible, $enabled}) => $active || $visible || $enabled && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_or_visible_or_enabled");
+    expect(cssName).toBe("$active_or_$visible_or_$enabled");
   });
 
   it("should guess the css name from a complex combination of AND and OR operators", () => {
@@ -133,19 +133,19 @@ describe("getCssName", () => {
       `({$active, $visible, $enabled}) => ($active && $visible) || ($visible && $enabled) && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active_and_visible_or_visible_and_enabled");
+    expect(cssName).toBe("$active_and_$visible_or_$visible_and_$enabled");
   });
 
   it("should guess the css name from a condition using Boolean() function", () => {
     const literal = getCssLiteral(`({$active}) => Boolean($active) && css\`\``);
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active");
+    expect(cssName).toBe("$active");
   });
 
   it("should guess the css name from a condition using double negation", () => {
     const literal = getCssLiteral(`({$active}) => !!$active && css\`\``);
     const cssName = getCssName(literal);
-    expect(cssName).toBe("active");
+    expect(cssName).toBe("$active");
   });
 
   it("should guess the css name from the variable name", () => {
@@ -165,6 +165,6 @@ describe("getCssName", () => {
       `({$user}) => $user.auth.loggedIn && css\`\``,
     );
     const cssName = getCssName(literal);
-    expect(cssName).toBe("userAuthLoggedIn");
+    expect(cssName).toBe("$userAuthLoggedIn");
   });
 });

--- a/packages/next-yak/loaders/__tests__/tsloader.test.ts
+++ b/packages/next-yak/loaders/__tests__/tsloader.test.ts
@@ -216,28 +216,28 @@ const FancyButton = styled(Button)\`
         font-size: 2rem;
         font-weight: bold;
       }
-      .Button__primary {
+      .Button__$primary {
         .Icon {
           background: black;
         }
       }
-      .Button__not_primary {
+      .Button__not_$primary {
         .Icon {
           background: white;
         }
       }
       .Button {
         .Icon {
-          width: var(--Button-width_18fi82j);
+          width: var(--Button__width_18fi82j);
         }
         display: block;
       }*/
       /*#__PURE__*/
       styled.button(__styleYak.Button, ({
         $primary
-      }) => $primary ? /*#__PURE__*/css(__styleYak.Button__primary) : /*#__PURE__*/css(__styleYak.Button__not_primary), {
+      }) => $primary ? /*#__PURE__*/css(__styleYak.Button__$primary) : /*#__PURE__*/css(__styleYak.Button__not_$primary), {
         \\"style\\": {
-          \\"--Button-width_18fi82j\\": ({
+          \\"--Button__width_18fi82j\\": ({
             $iconWidth
           }) => ($iconWidth) + \\"px\\"
         }
@@ -405,7 +405,7 @@ const headline = css\`
       const headline =
       /*YAK Extracted CSS:
       .headline {
-        transition: color var(--headline-transition_18fi82j) var(--headline-transition_18fi82j_1);
+        transition: color var(--headline__transition_18fi82j) var(--headline__transition_18fi82j_1);
         display: block;
       }
       .headline__headline {
@@ -417,10 +417,10 @@ const headline = css\`
       /*#__PURE__*/
       css(__styleYak.headline, css\`color: orange\`, css\`color: blue\`, {
         \\"style\\": {
-          \\"--headline-transition_18fi82j\\": ({
+          \\"--headline__transition_18fi82j\\": ({
             i
           }) => i * 100 + \\"ms\\",
-          \\"--headline-transition_18fi82j_1\\": ({
+          \\"--headline__transition_18fi82j_1\\": ({
             easing
           }) => easing
         }
@@ -629,7 +629,7 @@ const Wrapper = styled.div\`
           font-size: 1.5rem;
         }
       }
-      .headline__primary {
+      .headline__$primary {
         @media (min-width: 640px) {
           font-size: 1.7rem;
         }
@@ -642,7 +642,7 @@ const Wrapper = styled.div\`
       /*#__PURE__*/
       css(__styleYak.headline, ({
         $primary
-      }) => $primary && /*#__PURE__*/css(__styleYak.headline__primary));"
+      }) => $primary && /*#__PURE__*/css(__styleYak.headline__$primary));"
     `);
   });
 
@@ -949,9 +949,9 @@ const Button = styled.button\`
       import __styleYak from \\"./page.yak.module.css!=!./page?./page.yak.module.css\\";
       const Button =
       /*YAK Extracted CSS:
-      .Button__primary {
+      .Button__$primary {
         background-color: #4CAF50;
-        text-indent: var(--Button__primary-text-indent_18fi82j);
+        text-indent: var(--Button__$primary__text-indent_18fi82j);
       }*/
       /*#__PURE__*/
       styled.button(({
@@ -959,9 +959,9 @@ const Button = styled.button\`
         $digits
       }) => {
         const indent = $digits * 10 + \\"px\\";
-        return $primary && /*#__PURE__*/css(__styleYak.Button__primary, {
+        return $primary && /*#__PURE__*/css(__styleYak.Button__$primary, {
           \\"style\\": {
-            \\"--Button__primary-text-indent_18fi82j\\": indent
+            \\"--Button__$primary__text-indent_18fi82j\\": indent
           }
         });
       });"
@@ -1102,22 +1102,22 @@ const Button = styled.button\`
           color: red;
         }
       }
-      .Button__primary {
+      .Button__$primary {
         .Icon {
           background: black;
         }
       }
-      .Button__primary_and_active {
+      .Button__$primary_and_$active {
         .Icon {
           color: red;
         }
       }
-      .Button__primary_and_active_and {
+      .Button__$primary_and_$active_and {
         .Icon {
           color: red;
         }
       }
-      .Button__not_primary {
+      .Button__not_$primary {
         .Icon {
           background: white;
         }
@@ -1126,7 +1126,7 @@ const Button = styled.button\`
         display: block;
       }*/
       /*#__PURE__*/
-      styled.button(__styleYak.Button, $primary => $primary ? /*#__PURE__*/css(__styleYak.Button__primary, $active => $active && /*#__PURE__*/css(__styleYak.Button__primary_and_active), $active => $active && Math.random() && /*#__PURE__*/css(__styleYak.Button__primary_and_active_and)) : /*#__PURE__*/css(__styleYak.Button__not_primary));"
+      styled.button(__styleYak.Button, $primary => $primary ? /*#__PURE__*/css(__styleYak.Button__$primary, $active => $active && /*#__PURE__*/css(__styleYak.Button__$primary_and_$active), $active => $active && Math.random() && /*#__PURE__*/css(__styleYak.Button__$primary_and_$active_and)) : /*#__PURE__*/css(__styleYak.Button__not_$primary));"
     `);
   });
 
@@ -1154,20 +1154,20 @@ const Button = styled.button\`
       const Button =
       /*YAK Extracted CSS:
       .Button {
-        padding: var(--Button-padding_18fi82j);
-        margin: var(--Button-margin_18fi82j);
-        z-index: var(--Button-z-index_18fi82j);
-        transform: translateX(var(--Button-transform_18fi82j)) translateY(var(--Button-transform_18fi82j_1));
+        padding: var(--Button__padding_18fi82j);
+        margin: var(--Button__margin_18fi82j);
+        z-index: var(--Button__z-index_18fi82j);
+        transform: translateX(var(--Button__transform_18fi82j)) translateY(var(--Button__transform_18fi82j_1));
         font-family: \\"Arial\\", sans-serif;
       }*/
       /*#__PURE__*/
       styled.button(__styleYak.Button, {
         \\"style\\": {
-          \\"--Button-padding_18fi82j\\": () => (10) + \\"rem\\",
-          \\"--Button-margin_18fi82j\\": () => (4 * 2) + \\"px\\",
-          \\"--Button-z-index_18fi82j\\": () => 10 + 4,
-          \\"--Button-transform_18fi82j\\": () => (10) + \\"px\\",
-          \\"--Button-transform_18fi82j_1\\": () => (10 / 2) + \\"px\\"
+          \\"--Button__padding_18fi82j\\": () => (10) + \\"rem\\",
+          \\"--Button__margin_18fi82j\\": () => (4 * 2) + \\"px\\",
+          \\"--Button__z-index_18fi82j\\": () => 10 + 4,
+          \\"--Button__transform_18fi82j\\": () => (10) + \\"px\\",
+          \\"--Button__transform_18fi82j_1\\": () => (10 / 2) + \\"px\\"
         }
       });"
     `);
@@ -1193,16 +1193,16 @@ const Button = styled.button\`
       const ClockNumber =
       /*YAK Extracted CSS:
       .ClockNumber {
-        transform: translate(-50%, -50%) rotate(var(--ClockNumber-transform_18fi82j))
-      translate(0, -88px) rotate(var(--ClockNumber-transform_18fi82j_1));
+        transform: translate(-50%, -50%) rotate(var(--ClockNumber__transform_18fi82j))
+      translate(0, -88px) rotate(var(--ClockNumber__transform_18fi82j_1));
       }*/
       /*#__PURE__*/
       styled.div(__styleYak.ClockNumber, {
         \\"style\\": {
-          \\"--ClockNumber-transform_18fi82j\\": ({
+          \\"--ClockNumber__transform_18fi82j\\": ({
             index
           }) => (index * 30) + \\"deg\\",
-          \\"--ClockNumber-transform_18fi82j_1\\": ({
+          \\"--ClockNumber__transform_18fi82j_1\\": ({
             index
           }) => (-index * 30) + \\"deg\\"
         }
@@ -1236,12 +1236,12 @@ const Button = styled.button\`
       const case1 =
       /*YAK Extracted CSS:
       .case1 {
-        padding: var(--case1-padding_18fi82j);
+        padding: var(--case1__padding_18fi82j);
       }*/
       /*#__PURE__*/
       css(__styleYak.case1, {
         \\"style\\": {
-          \\"--case1-padding_18fi82j\\": __yak_unitPostFix(({
+          \\"--case1__padding_18fi82j\\": __yak_unitPostFix(({
             $indent
           }) => {
             if ($indent > 0) {
@@ -1279,31 +1279,31 @@ const Button = styled.button\`
       const mixin1 =
       /*YAK Extracted CSS:
       .mixin1 {
-        padding: var(--mixin1-padding_18fi82j);
+        padding: var(--mixin1__padding_18fi82j);
       }*/
       /*#__PURE__*/
       css(__styleYak.mixin1, {
         \\"style\\": {
-          \\"--mixin1-padding_18fi82j\\": () => (4) + \\"px\\"
+          \\"--mixin1__padding_18fi82j\\": () => (4) + \\"px\\"
         }
       });
       const value = 10;
       const mixin2 =
       /*YAK Extracted CSS:
       .mixin2 {
-        margin: var(--mixin2-margin_18fi82j);
-        top: var(--mixin2-top_18fi82j);
-        bottom: var(--mixin2-bottom_18fi82j);
-        left: var(--mixin2-left_18fi82j);
+        margin: var(--mixin2__margin_18fi82j);
+        top: var(--mixin2__top_18fi82j);
+        bottom: var(--mixin2__bottom_18fi82j);
+        left: var(--mixin2__left_18fi82j);
         right: 10px;
       }*/
       /*#__PURE__*/
       css(__styleYak.mixin2, {
         \\"style\\": {
-          \\"--mixin2-margin_18fi82j\\": () => (size) + \\"px\\",
-          \\"--mixin2-top_18fi82j\\": () => (spacing.xs) + \\"px\\",
-          \\"--mixin2-bottom_18fi82j\\": () => (spacing[0]) + \\"PX\\",
-          \\"--mixin2-left_18fi82j\\": () => (spacing()) + \\"px\\"
+          \\"--mixin2__margin_18fi82j\\": () => (size) + \\"px\\",
+          \\"--mixin2__top_18fi82j\\": () => (spacing.xs) + \\"px\\",
+          \\"--mixin2__bottom_18fi82j\\": () => (spacing[0]) + \\"PX\\",
+          \\"--mixin2__left_18fi82j\\": () => (spacing()) + \\"px\\"
         }
       });"
     `);
@@ -1801,7 +1801,7 @@ describe("css prop", () => {
         const Elem = props => <div {...__yak_mergeCssProp(props,
         /*YAK Extracted CSS:
         .Elem {
-          padding: var(--Elem-padding_18fi82j);
+          padding: var(--Elem__padding_18fi82j);
         }
         .Elem__propsActive {
           color: orange;
@@ -1809,7 +1809,7 @@ describe("css prop", () => {
         /*#__PURE__*/
         css(__styleYak.Elem, () => props.active && /*#__PURE__*/css(__styleYak.Elem__propsActive), {
           \\"style\\": {
-            \\"--Elem-padding_18fi82j\\": () => (props.dynamicPadding ? '10px' : \\"0\\") + \\"px\\"
+            \\"--Elem__padding_18fi82j\\": () => (props.dynamicPadding ? '10px' : \\"0\\") + \\"px\\"
           }
         })({}))} />;"
       `);

--- a/packages/next-yak/loaders/babel-yak-plugin.ts
+++ b/packages/next-yak/loaders/babel-yak-plugin.ts
@@ -685,7 +685,7 @@ e.g.:
         }
 
         const cssVarName = createUniqueName(
-          `${identifier}-${parsedCss.state.currentDeclaration.property}`,
+          `${identifier}__${parsedCss.state.currentDeclaration.property}`,
           true,
         );
         cssVariables[`--${cssVarName}`] = quasiExpression;

--- a/packages/next-yak/loaders/lib/getCssName.ts
+++ b/packages/next-yak/loaders/lib/getCssName.ts
@@ -134,5 +134,5 @@ export default function getCssName(
     const mixinName = getStyledComponentName(literal);
     return mixinName ? mixinName : "yak";
   }
-  return conditions.join("_").replace(/\$/g, "");
+  return conditions.join("_");
 }


### PR DESCRIPTION
use `__` as separator for css variables:

old: `color: var(--headline-color_18fi82j);`
new: `color: var(--headline__color_18fi82j);

don't remove the `$` from the variable:

old: `.Button__primary {`
new: `.Button__$primary {`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated CSS variable names to include double underscores for consistency.
  - Modified CSS class names in test cases to reflect updated naming conventions.

- **Refactor**
  - Renamed CSS variables and class names by introducing prefixes like `$` and `__` to improve readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->