### PR TITLE
enabling step debug logging for codspeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_STEP_DEBUG: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -15,10 +15,6 @@ on:
       - ".github/workflows/codspeed.yml"
   workflow_dispatch:
 
-# enable step debug logging
-env:
-  ACTIONS_STEP_DEBUG: true
-
 jobs:
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,8 +18,6 @@ on:
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_STEP_DEBUG: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -49,6 +49,8 @@ jobs:
         run: cd packages/benchmark && pnpm run codspeed
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v2
+        env:
+          CODSPEED_DEBUG: true
         with:
           working-directory: "packages/benchmark"
           run: NODE_ENV=production node --enable-source-maps ./codspeed/dist/index.bench.mjs

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,18 +2,22 @@ name: codspeed-benchmarks
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
-      - 'packages/next-yak/**'
-      - 'packages/benchmark/**'
-      - '.github/workflows/codspeed.yml'
+      - "packages/next-yak/**"
+      - "packages/benchmark/**"
+      - ".github/workflows/codspeed.yml"
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
-      - 'packages/next-yak/**'
-      - 'packages/benchmark/**'
-      - '.github/workflows/codspeed.yml'
+      - "packages/next-yak/**"
+      - "packages/benchmark/**"
+      - ".github/workflows/codspeed.yml"
   workflow_dispatch:
+
+# enable step debug logging
+env:
+  ACTIONS_STEP_DEBUG: true
 
 jobs:
   benchmarks:
@@ -48,9 +52,9 @@ jobs:
       - name: Build Yak
         run: pnpm run build
       - name: Build benchmark suite
-        run: cd packages/benchmark && pnpm run codspeed 
+        run: cd packages/benchmark && pnpm run codspeed
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           working-directory: "packages/benchmark"
           run: NODE_ENV=production node --enable-source-maps ./codspeed/dist/index.bench.mjs


### PR DESCRIPTION
Adrien gave us a great hint to find out why codspeed became flaky:

> By looking at this log from a run, it seems that now the node flags needed to make node's execution non-flaky are no longer present: https://github.com/jantimon/next-yak/actions/runs/9926270270/job/27419653757?pr=120#step:10:27
> To continue investigating, can you activate step debug logging:https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging, and create a PR?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added `ACTIONS_STEP_DEBUG: true` environment variable in the benchmarks job to aid in debugging.
  - Updated the workflow file `codspeed.yml` to improve indentation of branch lists and paths.
  - Upgraded the action version for running benchmarks from `v1` to `v2` to ensure compatibility and access to the latest features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->