### PR TITLE
fix keyframes order

### DIFF
--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -561,7 +561,7 @@ where
             PropName::Num(value) => Some(Atom::from(value.value.to_string())),
             PropName::BigInt(value) => Some(Atom::from(value.value.to_string())),
             // Skip computed property names
-            PropName::Computed(_) => None, 
+            PropName::Computed(_) => None,
           };
 
           if let Some(part) = new_part {

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -271,7 +271,7 @@ where
               // constant mixins e.g.
               // const highlight = css`color: red;`
               // const Button = styled.button`&:hover { ${highlight}; }`
-              if is_valid_tagged_tpl(&tagged_tpl, self.yak_library_imports.yak_css_idents.clone()) {
+              if is_valid_tagged_tpl(&tagged_tpl, &self.yak_library_imports.yak_css_idents) {
                 let (inline_runtime_exprs, inline_runtime_css_vars) =
                   self.process_yak_literal(&mut tagged_tpl.clone(), css_state.clone());
                 runtime_expressions.extend(inline_runtime_exprs);
@@ -282,7 +282,7 @@ where
               // const highlight = keyframes`from { color: red; }`
               else if is_valid_tagged_tpl(
                 &tagged_tpl,
-                self.yak_library_imports.yak_keyframes_idents.clone(),
+                &self.yak_library_imports.yak_keyframes_idents,
               ) {
                 // Create a unique name for the keyframe
                 let keyframe_name = self
@@ -340,7 +340,7 @@ where
         // Handle inline css literals
         // e.g. styled.button`${css`color: red;`};`
         else if let Expr::TaggedTpl(tpl) = &mut **expr {
-          if is_valid_tagged_tpl(tpl, self.yak_library_imports.yak_css_idents.clone()) {
+          if is_valid_tagged_tpl(tpl, &self.yak_library_imports.yak_css_idents) {
             let (inline_runtime_exprs, inline_runtime_css_vars) =
               self.process_yak_literal(tpl, css_state.clone());
             runtime_expressions.extend(inline_runtime_exprs);
@@ -581,7 +581,7 @@ where
       if let Some(scoped_name) = extract_ident_and_parts(n) {
         if let Some(constant_value) = self.variables.get_const_value(&scoped_name) {
           if let Expr::TaggedTpl(tpl) = *constant_value {
-            if is_valid_tagged_tpl(&tpl, self.yak_library_imports.yak_css_idents.clone()) {
+            if is_valid_tagged_tpl(&tpl, &self.yak_library_imports.yak_css_idents) {
               let replacement_before = self.expression_replacement.clone();
               let tpl = &mut tpl.clone();
               tpl.span = n.span();

--- a/packages/yak-swc/yak_swc/src/utils/ast_helper.rs
+++ b/packages/yak-swc/yak_swc/src/utils/ast_helper.rs
@@ -92,18 +92,21 @@ pub fn create_member_prop_from_string(s: String) -> MemberProp {
 /// 2. Simple identifiers (e.g., `primaryColor`) -> Some((primaryColor#0, ["primaryColor"]))
 pub fn extract_ident_and_parts(expr: &Expr) -> Option<ScopedVariableReference> {
   match &expr {
-    Expr::Member(member) => member_expr_to_strings(member).map_or_else(
+    Expr::Member(member_expr) => member_expr_to_strings(member_expr).map_or_else(
       || {
         HANDLER.with(|handler| {
           handler
-            .struct_span_err(member.span, "Could not parse member expression")
+            .struct_span_err(member_expr.span, "Could not parse member expression")
             .emit();
         });
         None
       },
-      |member_exp_strings| {
-        let (root_ident, props) = member_exp_strings;
-        Some(ScopedVariableReference::new(root_ident.to_id(), props))
+      |member_parts| {
+        let (base_ident, member_chain) = member_parts;
+        Some(ScopedVariableReference::new(
+          base_ident.to_id(),
+          member_chain,
+        ))
       },
     ),
     Expr::Ident(ident) => Some(ScopedVariableReference::new(

--- a/packages/yak-swc/yak_swc/src/utils/ast_helper.rs
+++ b/packages/yak-swc/yak_swc/src/utils/ast_helper.rs
@@ -115,10 +115,10 @@ pub fn extract_ident_and_parts(expr: &Expr) -> Option<ScopedVariableReference> {
 }
 
 /// Get a constant template literal from an expression
-pub fn is_valid_tagged_tpl(tagged_tpl: &TaggedTpl, literal_name: FxHashSet<Id>) -> bool {
+pub fn is_valid_tagged_tpl(tagged_tpl: &TaggedTpl, literal_names: &FxHashSet<Id>) -> bool {
   let TaggedTpl { tag, .. } = tagged_tpl;
   if let Expr::Ident(id) = &**tag {
-    if literal_name.contains(&id.to_id()) {
+    if literal_names.contains(&id.to_id()) {
       return true;
     }
   }

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -27,7 +27,7 @@ pub struct VariableVisitor {
 /// - a variable e.g. foo -> (foo#3, [foo])
 /// - a member expression e.g. foo.bar -> (foo#3, [foo, bar])
 pub struct ScopedVariableReference {
-  /// The swc id of the variable 
+  /// The swc id of the variable
   pub id: Id,
   /// The parts of the variable reference
   /// - e.g. foo.bar.baz -> [foo, bar, baz]

--- a/packages/yak-swc/yak_swc/src/yak_imports.rs
+++ b/packages/yak-swc/yak_swc/src/yak_imports.rs
@@ -146,10 +146,10 @@ impl VisitMut for YakImportVisitor {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use swc_core::ecma::transforms::testing::test_transform;
-  use swc_core::ecma::visit::as_folder;
   use swc_core::atoms::atom;
   use swc_core::common::SyntaxContext;
+  use swc_core::ecma::transforms::testing::test_transform;
+  use swc_core::ecma::visit::as_folder;
 
   #[test]
   fn test_yak_import_visitor_no_yak() {
@@ -216,9 +216,10 @@ mod tests {
       "#,
       true,
     );
-    assert!(visitor.yak_css_idents.contains(&Id::from((atom!("css"), SyntaxContext::empty()))));
+    assert!(visitor
+      .yak_css_idents
+      .contains(&Id::from((atom!("css"), SyntaxContext::empty()))));
   }
-
 
   #[test]
   fn test_yak_import_visitor_renamed_css_ident() {
@@ -236,7 +237,9 @@ mod tests {
       "#,
       true,
     );
-    assert!(visitor.yak_css_idents.contains(&Id::from((atom!("myCss"), SyntaxContext::empty()))));
+    assert!(visitor
+      .yak_css_idents
+      .contains(&Id::from((atom!("myCss"), SyntaxContext::empty()))));
   }
 
   #[test]
@@ -255,7 +258,9 @@ mod tests {
       "#,
       true,
     );
-    assert!(visitor.yak_keyframes_idents.contains(&Id::from((atom!("keyframes"), SyntaxContext::empty()))));
+    assert!(visitor
+      .yak_keyframes_idents
+      .contains(&Id::from((atom!("keyframes"), SyntaxContext::empty()))));
   }
 
   #[test]
@@ -274,7 +279,9 @@ mod tests {
       "#,
       true,
     );
-    assert!(visitor.yak_keyframes_idents.contains(&Id::from((atom!("myKeyframes"), SyntaxContext::empty()))));
+    assert!(visitor
+      .yak_keyframes_idents
+      .contains(&Id::from((atom!("myKeyframes"), SyntaxContext::empty()))));
   }
 
   #[test]

--- a/packages/yak-swc/yak_swc/src/yak_imports.rs
+++ b/packages/yak-swc/yak_swc/src/yak_imports.rs
@@ -19,6 +19,10 @@ pub struct YakImportVisitor {
   /// Most of the time it is just `css#0` for `import { css } from "next-yak"` \
   /// but it might also contain renamings like `import { css as css_ } from "next-yak"`
   pub yak_css_idents: FxHashSet<Id>,
+  /// Local Identifiers for the next-yak keyframes function \
+  /// Most of the time it is just `keyframes#0` for `import { keyframes } from "next-yak"` \
+  /// but it might also contain renamings like `import { keyframes as keyframes_ } from "next-yak"`
+  pub yak_keyframes_idents: FxHashSet<Id>,
 }
 
 const UTILITIES: &[&str] = &["unitPostFix", "mergeCssProp"];
@@ -29,6 +33,7 @@ impl YakImportVisitor {
       yak_library_imports: FxHashMap::default(),
       yak_utilities: FxHashMap::default(),
       yak_css_idents: FxHashSet::default(),
+      yak_keyframes_idents: FxHashSet::default(),
     }
   }
 
@@ -129,6 +134,8 @@ impl VisitMut for YakImportVisitor {
           self.yak_library_imports.insert(local, imported.clone());
           if imported.0 == "css" {
             self.yak_css_idents.insert(named.local.to_id());
+          } else if imported.0 == "keyframes" {
+            self.yak_keyframes_idents.insert(named.local.to_id());
           }
         }
       }
@@ -141,6 +148,8 @@ mod tests {
   use super::*;
   use swc_core::ecma::transforms::testing::test_transform;
   use swc_core::ecma::visit::as_folder;
+  use swc_core::atoms::atom;
+  use swc_core::common::SyntaxContext;
 
   #[test]
   fn test_yak_import_visitor_no_yak() {
@@ -189,5 +198,91 @@ mod tests {
       true,
     );
     assert_eq!(visitor.is_using_next_yak(), true);
+  }
+
+  #[test]
+  fn test_yak_import_visitor_css_ident() {
+    let mut visitor = YakImportVisitor::new();
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      r#"
+        import { css } from "next-yak";
+        const styles = css`color: red;`;
+      "#,
+      r#"
+        import { css } from "next-yak/internal";
+        const styles = css`color: red;`;
+      "#,
+      true,
+    );
+    assert!(visitor.yak_css_idents.contains(&Id::from((atom!("css"), SyntaxContext::empty()))));
+  }
+
+
+  #[test]
+  fn test_yak_import_visitor_renamed_css_ident() {
+    let mut visitor = YakImportVisitor::new();
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      r#"
+        import { css as myCss } from "next-yak";
+        const styles = myCss`color: red;`;
+      "#,
+      r#"
+        import { css as myCss } from "next-yak/internal";
+        const styles = myCss`color: red;`;
+      "#,
+      true,
+    );
+    assert!(visitor.yak_css_idents.contains(&Id::from((atom!("myCss"), SyntaxContext::empty()))));
+  }
+
+  #[test]
+  fn test_yak_import_visitor_keyframes_ident() {
+    let mut visitor = YakImportVisitor::new();
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      r#"
+        import { keyframes } from "next-yak";
+        const animation = keyframes`from { opacity: 0; } to { opacity: 1; }`;
+      "#,
+      r#"
+        import { keyframes } from "next-yak/internal";
+        const animation = keyframes`from { opacity: 0; } to { opacity: 1; }`;
+      "#,
+      true,
+    );
+    assert!(visitor.yak_keyframes_idents.contains(&Id::from((atom!("keyframes"), SyntaxContext::empty()))));
+  }
+
+  #[test]
+  fn test_yak_import_visitor_renamed_keyframes_ident() {
+    let mut visitor = YakImportVisitor::new();
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      r#"
+        import { keyframes as myKeyframes } from "next-yak";
+        const animation = myKeyframes`from { opacity: 0; } to { opacity: 1; }`;
+      "#,
+      r#"
+        import { keyframes as myKeyframes } from "next-yak/internal";
+        const animation = myKeyframes`from { opacity: 0; } to { opacity: 1; }`;
+      "#,
+      true,
+    );
+    assert!(visitor.yak_keyframes_idents.contains(&Id::from((atom!("myKeyframes"), SyntaxContext::empty()))));
+  }
+
+  #[test]
+  fn test_yak_import_visitor_utility_ident() {
+    let mut visitor = YakImportVisitor::new();
+    let ident = visitor.get_yak_utility_ident("unitPostFix".to_string());
+    assert_eq!(ident.sym, "__yak_unitPostFix");
+    let ident = visitor.get_yak_utility_ident("mergeCssProp".to_string());
+    assert_eq!(ident.sym, "__yak_mergeCssProp");
   }
 }

--- a/packages/yak-swc/yak_swc/src/yak_transforms.rs
+++ b/packages/yak-swc/yak_swc/src/yak_transforms.rs
@@ -314,9 +314,9 @@ pub struct TransformKeyframes {
 }
 
 impl TransformKeyframes {
-  pub fn new() -> TransformKeyframes {
+  pub fn new(animation_name: Option<&String>) -> TransformKeyframes {
     TransformKeyframes {
-      animation_name: None,
+      animation_name: animation_name.cloned(),
     }
   }
 }
@@ -328,8 +328,13 @@ impl YakTransform for TransformKeyframes {
     declaration_name: &str,
     _previous_parser_state: Option<ParserState>,
   ) -> ParserState {
-    let css_identifier = naming_convention.generate_unique_name(declaration_name);
-    self.animation_name = Some(css_identifier.clone());
+    let css_identifier = if self.animation_name.is_none() {
+      let new_identifier = naming_convention.generate_unique_name(declaration_name);
+      self.animation_name = Some(new_identifier.clone());
+      new_identifier
+    } else {
+      self.animation_name.clone().unwrap()
+    };
     let mut parser_state = ParserState::new();
     parser_state.current_scopes = vec![CssScope {
       name: format!("@keyframes {}", css_identifier),

--- a/packages/yak-swc/yak_swc/src/yak_transforms.rs
+++ b/packages/yak-swc/yak_swc/src/yak_transforms.rs
@@ -314,9 +314,9 @@ pub struct TransformKeyframes {
 }
 
 impl TransformKeyframes {
-  pub fn new(animation_name: Option<&String>) -> TransformKeyframes {
+  pub fn new(animation_name: String) -> TransformKeyframes {
     TransformKeyframes {
-      animation_name: animation_name.cloned(),
+      animation_name: Some(animation_name),
     }
   }
 }

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/input.tsx
@@ -1,0 +1,30 @@
+import { styled, css, keyframes } from "next-yak";
+
+export const FadeInText = styled.p<{ $reverse?: boolean }>`
+  ${({ $reverse }) => $reverse ? css`
+    animation: ${fadeOut} 1s ease-in;
+    ` : css`
+    animation: ${fadeIn} 1s ease-in;
+  `}
+  
+  font-size: 18px;
+  color: #333;
+`;
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const fadeOut = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-function/output.tsx
@@ -1,0 +1,34 @@
+import { styled, css, keyframes } from "next-yak/internal";
+import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
+export const FadeInText = /*YAK Extracted CSS:
+.FadeInText__$reverse {
+  animation: fadeOut 1s ease-in;
+}
+.FadeInText__not_$reverse {
+  animation: fadeIn 1s ease-in;
+}
+.FadeInText {
+  font-size: 18px;
+  color: #333;
+}
+*/ /*#__PURE__*/ styled.p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse));
+const fadeIn = /*YAK Extracted CSS:
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+*/ /*#__PURE__*/ keyframes(__styleYak.fadeIn);
+const fadeOut = /*YAK Extracted CSS:
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+*/ /*#__PURE__*/ keyframes(__styleYak.fadeOut);

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/input.tsx
@@ -32,3 +32,27 @@ const animations = {
     }
 `,
 };
+
+const slides = {
+  200: keyframes`
+    to {
+      transform: translate(200px, 200px);
+    }
+`,
+  "x400": keyframes`
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(400px);
+    }
+`,
+};
+
+export const FancyButton = styled.button`
+  background-color: #f00;
+  animation: ${slides.x400} 1s ease-in-out, ${animations.fadeIn} 1s ease-in;
+  &:hover {
+    animation: ${slides["200"]} 1s ease-in-out, ${animations.fadeOut} 1s ease-in;
+  }
+`;

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/input.tsx
@@ -1,0 +1,34 @@
+import { styled, css, keyframes } from "next-yak";
+
+export const FadeInText = styled.p<{ $reverse?: boolean }>`
+  ${({ $reverse }) =>
+    $reverse
+      ? css`
+          animation: ${animations.fadeOut} 1s ease-in;
+        `
+      : css`
+          animation: ${animations.fadeIn} 1s ease-in;
+        `}
+
+  font-size: 18px;
+  color: #333;
+`;
+
+const animations = {
+  fadeIn: keyframes`
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+`,
+  fadeOut: keyframes`
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+`,
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.tsx
@@ -1,0 +1,36 @@
+import { styled, css, keyframes } from "next-yak/internal";
+import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
+export const FadeInText = /*YAK Extracted CSS:
+.FadeInText__$reverse {
+  animation: animations_fadeOut 1s ease-in;
+}
+.FadeInText__not_$reverse {
+  animation: animations_fadeIn 1s ease-in;
+}
+.FadeInText {
+  font-size: 18px;
+  color: #333;
+}
+*/ /*#__PURE__*/ styled.p(__styleYak.FadeInText, ({ $reverse })=>$reverse ? /*#__PURE__*/ css(__styleYak.FadeInText__$reverse) : /*#__PURE__*/ css(__styleYak.FadeInText__not_$reverse));
+const animations = {
+    fadeIn: /*YAK Extracted CSS:
+@keyframes animations_fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+*/ /*#__PURE__*/ keyframes(__styleYak.animations_fadeIn),
+    fadeOut: /*YAK Extracted CSS:
+@keyframes animations_fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+*/ /*#__PURE__*/ keyframes(__styleYak.animations_fadeOut)
+};

--- a/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/keyframe-animations-object/output.tsx
@@ -34,3 +34,31 @@ const animations = {
 }
 */ /*#__PURE__*/ keyframes(__styleYak.animations_fadeOut)
 };
+const slides = {
+    200: /*YAK Extracted CSS:
+@keyframes slides_200 {
+  to {
+    transform: translate(200px, 200px);
+  }
+}
+*/ /*#__PURE__*/ keyframes(__styleYak.slides_200),
+    "x400": /*YAK Extracted CSS:
+@keyframes slides_x400 {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(400px);
+  }
+}
+*/ /*#__PURE__*/ keyframes(__styleYak.slides_x400)
+};
+export const FancyButton = /*YAK Extracted CSS:
+.FancyButton {
+  background-color: #f00;
+  animation: slides_x400 1s ease-in-out, animations_fadeIn 1s ease-in;
+  &:hover {
+    animation: slides_200 1s ease-in-out, animations_fadeOut 1s ease-in;
+  }
+}
+*/ /*#__PURE__*/ styled.button(__styleYak.FancyButton);


### PR DESCRIPTION
This pull request addresses issue #166, where keyframe animations defined after their usage in styled components cause an "Unsupported template literal in css expression" error. The solution involves the following key changes:

- Introduced `ScopedVariableReference` to manage JavaScript variable references more effectively, ensuring that both simple and complex references (e.g., `foo` and `foo.bar`) are handled consistently
- Updated the handling of keyframe animations and nested CSS expressions to resolve references correctly, even when keyframes are defined after their usage

The solution is to link keyframe references with its declaration even before it was declared and reuse this name later during the actual declaration. This ensures that animations work seamlessly regardless of their order in the file