### PR TITLE
Fix nested member expressions

### DIFF
--- a/packages/next-yak/package.json
+++ b/packages/next-yak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-yak",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "types": "./dist/",
   "license": "MIT",
@@ -78,7 +78,7 @@
   "dependencies": {
     "@babel/core": "7.23.2",
     "@babel/plugin-syntax-typescript": "7.22.5",
-    "yak-swc": "0.4.0"
+    "yak-swc": "0.4.1"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.14",

--- a/packages/yak-swc/package.json
+++ b/packages/yak-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yak-swc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "next-yak rust based swc plugin to compile styled components at build time",
   "homepage": "https://yak.js.org/",
   "repository": {

--- a/packages/yak-swc/yak_swc/src/utils/ast_helper.rs
+++ b/packages/yak-swc/yak_swc/src/utils/ast_helper.rs
@@ -57,7 +57,6 @@ pub fn member_expr_to_strings(member_expr: &MemberExpr) -> Option<(Ident, Vec<At
       let result = member_expr_to_strings(&member)?;
       let (root_ident, mut nested_props) = result;
       nested_props.extend(props);
-      nested_props.insert(0, root_ident.sym.clone());
       Some((root_ident, nested_props))
     }
     _ => None,

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/input.tsx
@@ -1,14 +1,15 @@
 import { styled } from "next-yak";
 // @ts-ignore
-import { colors } from "./colors";
+import { colors } from "./colorDefinitions";
 // @ts-ignore
-import { fonts } from "./fonts";
+import { fonts } from "./fontDefinitions";
 // @ts-ignore
-import { sizes } from "./sizes";
+import { sizes } from "./sizeDefinitions";
 
 export const Button = styled.button`
   font-size: ${fonts.sm};
   color: ${colors.dark.primary};
+  border-color: ${colors.shadows.dark.primary};
   background-color: ${colors.light["full opacity"]};
   height: ${sizes[0]};
 `;

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.tsx
@@ -1,16 +1,17 @@
 import { styled } from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 // @ts-ignore
-import { colors } from "./colors";
+import { colors } from "./colorDefinitions";
 // @ts-ignore
-import { fonts } from "./fonts";
+import { fonts } from "./fontDefinitions";
 // @ts-ignore
-import { sizes } from "./sizes";
+import { sizes } from "./sizeDefinitions";
 export const Button = /*YAK Extracted CSS:
 .Button {
-  font-size: --yak-css-import: url("./fonts:fonts:sm",mixin);
-  color: --yak-css-import: url("./colors:colors:dark:primary",mixin);
-  background-color: --yak-css-import: url("./colors:colors:light:full%20opacity",mixin);
-  height: --yak-css-import: url("./sizes:sizes:0",mixin);
+  font-size: --yak-css-import: url("./fontDefinitions:fonts:sm",mixin);
+  color: --yak-css-import: url("./colorDefinitions:colors:dark:primary",mixin);
+  border-color: --yak-css-import: url("./colorDefinitions:colors:shadows:dark:primary",mixin);
+  background-color: --yak-css-import: url("./colorDefinitions:colors:light:full%20opacity",mixin);
+  height: --yak-css-import: url("./sizeDefinitions:sizes:0",mixin);
 }
 */ /*#__PURE__*/ styled.button(__styleYak.Button);

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-constants/output.tsx
@@ -9,8 +9,8 @@ import { sizes } from "./sizes";
 export const Button = /*YAK Extracted CSS:
 .Button {
   font-size: --yak-css-import: url("./fonts:fonts:sm",mixin);
-  color: --yak-css-import: url("./colors:colors:colors:dark:primary",mixin);
-  background-color: --yak-css-import: url("./colors:colors:colors:light:full%20opacity",mixin);
+  color: --yak-css-import: url("./colors:colors:dark:primary",mixin);
+  background-color: --yak-css-import: url("./colors:colors:light:full%20opacity",mixin);
   height: --yak-css-import: url("./sizes:sizes:0",mixin);
 }
 */ /*#__PURE__*/ styled.button(__styleYak.Button);

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.tsx
@@ -32,7 +32,7 @@ export const Button4 = /*YAK Extracted CSS:
 export const Button5 = /*YAK Extracted CSS:
 .Button5 {
   --yak-css-import: url("./fonts:fonts:h1",mixin);
-  --yak-css-import: url("./fancy:fancy:fancy:mixins:specialEffect",mixin);
+  --yak-css-import: url("./fancy:fancy:mixins:specialEffect",mixin);
   color: green;
 }
 */ /*#__PURE__*/ styled.button(__styleYak.Button5);
@@ -41,7 +41,7 @@ export const Button6 = /*YAK Extracted CSS:
   &:hover {
     --yak-css-import: url("./constants.yak:yakMixin",selector);
   }
-  --yak-css-import: url("./fancy:fancy:fancy:mixins:specialEffect",mixin)
+  --yak-css-import: url("./fancy:fancy:mixins:specialEffect",mixin)
 ;
   color: green;
 }


### PR DESCRIPTION
Member expressions with more than one level were handled incorrect.

```css
padding: ${layout.sidePaddings.val}
```
is turned into a doubled root ident
```css
padding: ${layout.layout.sidePaddings.val}
```

This change will fix that.