### PR TITLE
add support for % units

### DIFF
--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -833,7 +833,8 @@ fn pure_annotation() -> Comment {
 /// Extracts the leading css unit from a css code
 /// Use a heuristic to determine if the unit is a valid css unit by checking the length
 fn extract_leading_css_unit(css: &str) -> Option<&str> {
-  let end = css.find(|c: char| !c.is_alphabetic()).unwrap_or(css.len());
+  let end = css.find(|c: char| !c.is_alphabetic() && c != '%'
+).unwrap_or(css.len());
   if end > 0 && end <= 4 {
     let unit = &css[..end];
     return Some(unit);

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -833,8 +833,9 @@ fn pure_annotation() -> Comment {
 /// Extracts the leading css unit from a css code
 /// Use a heuristic to determine if the unit is a valid css unit by checking the length
 fn extract_leading_css_unit(css: &str) -> Option<&str> {
-  let end = css.find(|c: char| !c.is_alphabetic() && c != '%'
-).unwrap_or(css.len());
+  let end = css
+    .find(|c: char| !c.is_alphabetic() && c != '%')
+    .unwrap_or(css.len());
   if end > 0 && end <= 4 {
     let unit = &css[..end];
     return Some(unit);

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/input.tsx
@@ -6,5 +6,7 @@ export const FlexContainer = styled.div`
   flex-direction: ${({ $direction }) => $direction || 'row'};
   justify-content: ${({ $justify }) => $justify || 'flex-start'};
   padding: 20px;
+  margin-bottom: ${({ $marginBottom }) => $marginBottom || '0'}px;
+  top: ${({ $top }) => $top * 20}%;
   background-color: #f0f0f0;
 `;

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
@@ -1,4 +1,4 @@
-import { styled } from "next-yak/internal";
+import { styled, __yak_unitPostFix } from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FlexContainer = /*YAK Extracted CSS:
 .FlexContainer {
@@ -7,12 +7,16 @@ export const FlexContainer = /*YAK Extracted CSS:
   flex-direction: var(--FlexContainer__flex-direction_o1wkyu);
   justify-content: var(--FlexContainer__justify-content_o1wkyu);
   padding: 20px;
+  margin-bottom: var(--FlexContainer__margin-bottom_o1wkyu);
+  top: var(--FlexContainer__top_o1wkyu);
   background-color: #f0f0f0;
 }
 */ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, {
     "style": {
         "--FlexContainer__align-items_o1wkyu": ({ $align })=>$align || 'stretch',
         "--FlexContainer__flex-direction_o1wkyu": ({ $direction })=>$direction || 'row',
-        "--FlexContainer__justify-content_o1wkyu": ({ $justify })=>$justify || 'flex-start'
+        "--FlexContainer__justify-content_o1wkyu": ({ $justify })=>$justify || 'flex-start',
+        "--FlexContainer__margin-bottom_o1wkyu": __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
+        "--FlexContainer__top_o1wkyu": __yak_unitPostFix(({ $top })=>$top * 20, "%")
     }
 });


### PR DESCRIPTION
Almost all CSS Values are alphabetic:
https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units

But there is also `%`

This pr adds support for `%`