### PR TITLE
add Build-time Evaluation for CSS Calculations

### DIFF
--- a/packages/yak-swc/yak_swc/src/math_evaluate.rs
+++ b/packages/yak-swc/yak_swc/src/math_evaluate.rs
@@ -1,0 +1,351 @@
+use swc_core::ecma::ast::*;
+
+use crate::utils::ast_helper::extract_ident_and_parts;
+use crate::variable_visitor::VariableVisitor;
+
+/// Try to evaluate a given expression
+/// e.g. `2 + 3 * 4` will return `14`
+pub fn try_evaluate(expr: &Expr, variable_visitor: &VariableVisitor) -> Option<f64> {
+  match expr {
+    Expr::Ident(_) | Expr::Member(_) => {
+      if let Some(scoped_variable_reference) = extract_ident_and_parts(expr) {
+        let value = variable_visitor.get_const_value(&scoped_variable_reference);
+        match value {
+          Some(expr) => try_evaluate(&expr, variable_visitor),
+          None => None,
+        }
+      } else {
+        None
+      }
+    }
+    Expr::Lit(Lit::Num(num)) => Some(num.value),
+    Expr::Bin(bin_expr) => {
+      match (&*bin_expr.left, &*bin_expr.right) {
+        (Expr::Bin(left_bin), right_expr) => {
+          // The precedence helps to prioritize multiplication and divitions over
+          // additions and subtractions
+          let left_precedence = get_precedence(&left_bin.op);
+          let current_precedence = get_precedence(&bin_expr.op);
+
+          if left_precedence <= current_precedence {
+            let left = try_evaluate(&bin_expr.left, variable_visitor)?;
+            let right = try_evaluate(right_expr, variable_visitor)?;
+            apply_op(&bin_expr.op, left, right)
+          } else {
+            // Need to evaluate the left binary expression first
+            let left_result = apply_op(
+              &left_bin.op,
+              try_evaluate(&left_bin.left, variable_visitor)?,
+              try_evaluate(&left_bin.right, variable_visitor)?,
+            )?;
+            let right = try_evaluate(right_expr, variable_visitor)?;
+            apply_op(&bin_expr.op, left_result, right)
+          }
+        }
+        _ => {
+          // Simple case: evaluate left to right
+          let left = try_evaluate(&bin_expr.left, variable_visitor)?;
+          let right = try_evaluate(&bin_expr.right, variable_visitor)?;
+          apply_op(&bin_expr.op, left, right)
+        }
+      }
+    }
+    Expr::Paren(paren_expr) => try_evaluate(&paren_expr.expr, variable_visitor),
+    _ => None,
+  }
+}
+
+fn get_precedence(op: &BinaryOp) -> u8 {
+  match op {
+    BinaryOp::Mul | BinaryOp::Div => 2,
+    BinaryOp::Add | BinaryOp::Sub => 1,
+    _ => 0,
+  }
+}
+
+fn apply_op(op: &BinaryOp, left: f64, right: f64) -> Option<f64> {
+  match op {
+    BinaryOp::Add => Some(left + right),
+    BinaryOp::Sub => Some(left - right),
+    BinaryOp::Mul => Some(left * right),
+    BinaryOp::Div => Some(left / right),
+    _ => None,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use swc_core::ecma::transforms::testing::test_transform;
+  use swc_core::ecma::visit::as_folder;
+  use swc_core::ecma::visit::VisitMut;
+  use swc_core::ecma::visit::VisitMutWith;
+
+  #[derive(Debug)]
+  pub struct TestVisitor {
+    target_name: String,
+    initializer: Option<Box<Expr>>,
+    variables: VariableVisitor,
+  }
+
+  impl TestVisitor {
+    pub fn new(target_name: &str) -> Self {
+      Self {
+        target_name: target_name.to_string(),
+        initializer: None,
+        variables: VariableVisitor::new(),
+      }
+    }
+
+    pub fn get_variable_initializer(&self) -> Option<&Expr> {
+      self.initializer.as_deref()
+    }
+
+    pub fn get_variable_visitor(&self) -> &VariableVisitor {
+      &self.variables
+    }
+  }
+
+  impl VisitMut for TestVisitor {
+    fn visit_mut_program(&mut self, program: &mut Program) {
+      let mut variable_visitor = VariableVisitor::new();
+      program.visit_mut_children_with(&mut variable_visitor);
+      self.variables = variable_visitor;
+      program.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_var_decl(&mut self, var: &mut VarDecl) {
+      for decl in &var.decls {
+        if let Pat::Ident(ident) = &decl.name {
+          if ident.sym.as_ref() == self.target_name {
+            if let Some(init) = &decl.init {
+              self.initializer = Some(init.clone());
+            }
+          }
+        }
+      }
+      var.visit_mut_children_with(self);
+    }
+  }
+
+  #[test]
+  fn test_operator_precedence() {
+    let code = r#"
+            const calc = 2 + 3 * 4;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(14.0)
+    ); // Should be 2 + (3 * 4), not (2 + 3) * 4
+  }
+
+  #[test]
+  fn test_complex_precedence() {
+    let code = r#"
+            const calc = 2 * 3 + 4 * 5;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(26.0)
+    ); // Should be (2 * 3) + (4 * 5)
+  }
+
+  #[test]
+  fn test_division_precedence() {
+    let code = r#"
+            const calc = 10 + 8 / 2;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(14.0)
+    ); // Should be 10 + (8 / 2)
+  }
+
+  #[test]
+  fn test_mixed_operations() {
+    let code = r#"
+            const calc = 2 * 3 + 4 / 2 - 1;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(7.0)
+    ); // Should be (2 * 3) + (4 / 2) - 1
+  }
+
+  #[test]
+  fn test_mixed_string_operations() {
+    let code = r#"
+            const calc = 2 * `3` + 4 / 2 - 1;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(try_evaluate(expr, visitor.get_variable_visitor()), None);
+  }
+
+  #[test]
+  fn test_parentheses_override_precedence() {
+    let code = r#"
+            const calc = (2 + 3) * 4;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(20.0)
+    ); // Parentheses should override normal precedence
+  }
+
+  #[test]
+  fn test_identifier_calculation() {
+    let code = r#"
+            const meaning_of_life = 42;
+            const calc = meaning_of_life / 2;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(21.0)
+    );
+  }
+
+  #[test]
+  fn test_nested_identifier_calculation() {
+    let code = r#"
+            const addition = 2 + 3 + 1;
+            const meaning_of_life = 42;
+            const calc = meaning_of_life + addition / 2;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(45.0)
+    );
+  }
+
+  #[test]
+  fn test_imported_identifier_calculation() {
+    let code = r#"
+            import { addition } from "sth";
+            const meaning_of_life = 42;
+            const calc = meaning_of_life + addition / 2;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(try_evaluate(expr, visitor.get_variable_visitor()), None);
+  }
+
+  #[test]
+  fn test_member_expression_calculation() {
+    let code = r#"
+            const sizes = { small: 1, medium: 2, large: 3 };
+            const meaning_of_life = 42;
+            const calc = meaning_of_life * sizes.medium;
+        "#;
+    let mut visitor = TestVisitor::new("calc");
+
+    test_transform(
+      Default::default(),
+      |_| as_folder(&mut visitor),
+      code,
+      code,
+      true,
+    );
+
+    let expr = visitor.get_variable_initializer().unwrap();
+    assert_eq!(
+      try_evaluate(expr, visitor.get_variable_visitor()),
+      Some(84.0)
+    );
+  }
+}

--- a/packages/yak-swc/yak_swc/src/variable_visitor.rs
+++ b/packages/yak-swc/yak_swc/src/variable_visitor.rs
@@ -59,8 +59,8 @@ impl VariableVisitor {
   /// Try to get a constant value for a variable id
   /// Supports normal constant values, object properties and array elements
   /// e.g. get_const_value(("primary#0", vec![atom!("primary"), atom!("red")]))
-  pub fn get_const_value(&mut self, scoped_name: &ScopedVariableReference) -> Option<Box<Expr>> {
-    if let Some(expr) = self.variables.get_mut(&scoped_name.id) {
+  pub fn get_const_value(&self, scoped_name: &ScopedVariableReference) -> Option<Box<Expr>> {
+    if let Some(expr) = self.variables.get(&scoped_name.id) {
       // Start with the initial expression
       let mut current_expr: &Expr = expr;
       // Iterate over the parts (skipping the first one as it's the variable name)

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/input.tsx
@@ -12,11 +12,13 @@ const colors = {
 };
 
 const borderRadius = "4px";
+const stacking = 1;
 
 export const Button = styled.button`
   background-color: ${colors.primary};
   color: ${colors.light};
-  padding: 10px 20px;
+  padding: 10px ${100 / 3}%;
+  z-index: ${stacking};
   border: none;
   border-radius: ${borderRadius};
   cursor: pointer;

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/output.tsx
@@ -11,11 +11,13 @@ const colors = {
     dark: "#343a40"
 };
 const borderRadius = "4px";
+const stacking = 1;
 export const Button = /*YAK Extracted CSS:
 .Button {
   background-color: #007bff;
   color: #f8f9fa;
-  padding: 10px 20px;
+  padding: 10px 33.3333%;
+  z-index: 1;
   border: none;
   border-radius: 4px;
   cursor: pointer;


### PR DESCRIPTION
This PR adds support for evaluating simple calculations in CSS template literals at build time, improving runtime performance while maintaining code readability.

## Changes
- Added a new expression evaluator that handles:
  - Basic arithmetic operations (+, -, *, /)
  - Constant values
  - Member expressions (e.g. `theme.spacing.lg * 2`)
  - Parentheses for precedence control
- Integrated evaluation into the CSS template literal transformer

## Examples

```jsx
// Input
const theme = {
  spacing: {
    base: 8,
    lg: 16
  }
};

const Container = styled.div`
  /* Simple calculations */
  width: ${300 / 2}px;
  height: ${40 * 3}px;
  
  /* With constants */
  padding: ${theme.spacing.base * 2}px ${theme.spacing.lg * 1.5}px;
  
  /* With parentheses */
  margin: ${(theme.spacing.base + 4) * 2}px;
`;

// Output (after build)
const Container = styled.div`
  width: 150px;
  height: 120px;
  padding: 16px 24px;
  margin: 24px;
`;
```

## Performance Impact
- Moves calculation overhead from runtime to build time
- No impact on development experience (calculations remain readable in source)
- Reduced bundle size (final CSS contains only computed values)

## Notes
- Only evaluates expressions that can be fully resolved at build time
- Maintains source readability while optimizing output

Fixes #174 