### PR TITLE
fix incorrect selector/mixin import kind detection in nested CSS

### DIFF
--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -242,29 +242,28 @@ where
           else if let Some((_import_source_type, module_path)) =
             self.variables.get_imported_variable(&scoped_name.id)
           {
-            let import_kind: ImportKind = match find_char(
-              &quasis[pair.index..]
-                .iter()
-                .map(|quasi| quasi.raw.as_str())
-                .collect::<String>(),
-              &[';', '{', '}', '@'],
-            ) {
-              Some((char, _)) =>
-              // e.g. styled.button`${Icon} { ... }`
-              {
-                if char == '{' {
-                  ImportKind::Selector
+            let code_after_expression = &quasis[pair.index + 1..]
+              .iter()
+              .map(|quasi| quasi.raw.as_str())
+              .collect::<String>();
+            let import_kind: ImportKind =
+              match find_char(&code_after_expression, &[';', '{', '}', '@']) {
+                Some((char, _)) =>
+                // e.g. styled.button`${Icon} { ... }`
+                {
+                  if char == '{' {
+                    ImportKind::Selector
+                  }
+                  // e.g. styled.button`${colors.primary} @media { ... }`
+                  // e.g. styled.button`.foo { ${colors.primary} }`
+                  // e.g. styled.button`${colors.primary};`
+                  else {
+                    ImportKind::Mixin
+                  }
                 }
-                // e.g. styled.button`${colors.primary} @media { ... }`
-                // e.g. styled.button`.foo { ${colors.primary} }`
-                // e.g. styled.button`${colors.primary};`
-                else {
-                  ImportKind::Mixin
-                }
-              }
-              // e.g. styled.button`${colors.primary}`
-              None => ImportKind::Mixin,
-            };
+                // e.g. styled.button`${colors.primary}`
+                None => ImportKind::Mixin,
+              };
             let cross_file_import_token =
               encode_module_import(module_path.as_str(), scoped_name.parts, import_kind);
 

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-mixin-import/output.tsx
@@ -39,7 +39,7 @@ export const Button5 = /*YAK Extracted CSS:
 export const Button6 = /*YAK Extracted CSS:
 .Button6 {
   &:hover {
-    --yak-css-import: url("./constants.yak:yakMixin",selector);
+    --yak-css-import: url("./constants.yak:yakMixin",mixin);
   }
   --yak-css-import: url("./fancy:fancy:mixins:specialEffect",mixin)
 ;

--- a/packages/yak-swc/yak_swc/tests/fixture/cross-file-selectors/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/cross-file-selectors/output.tsx
@@ -7,7 +7,7 @@ export const Button = /*YAK Extracted CSS:
 .Button {
   font-size: 1rem;
   color: green;
-  --yak-css-import: url("./Icon:Icon",mixin) {
+  --yak-css-import: url("./Icon:Icon",selector) {
     color: red;
   }
   --yak-css-import: url("./Icon:Icon",selector) --yak-css-import: url("./Icon:Icon",selector) {


### PR DESCRIPTION
## Issue
When using an imported mixin within a nested CSS rule, it was incorrectly being identified as a selector if there was a `{` character in the surrounding CSS context. For example:

```tsx
export const Button = styled.button`
  &:hover {
    ${yakMixin};  // Was incorrectly marked as selector
  }
`;
```

This caused the import to be encoded with `selector` instead of `mixin`:
```css
/* Before: Incorrect */
--yak-css-import: url("./constants.yak:yakMixin",selector);

/* After: Correct */
--yak-css-import: url("./constants.yak:yakMixin",mixin);
```

## Fix
Updated the logic in `process_yak_literal` to look only at the code *after* the current expression when determining the import kind. This ensures that surrounding CSS context (like the `{` from `&:hover {`) doesn't interfere with the detection.

```rust
let code_after_expression = &quasis[pair.index + 1..]
  .iter()
  .map(|quasi| quasi.raw.as_str())
  .collect::<String>();
let import_kind: ImportKind =
  match find_char(&code_after_expression, &[';', '{', '}', '@']) {
    Some((char, _)) => {
      if char == '{' {
        ImportKind::Selector  // Only if { comes directly after expression
      } else {
        ImportKind::Mixin
      }
    }
    None => ImportKind::Mixin,
  };
```
