### PR TITLE
add layer example

### DIFF
--- a/packages/example/app/globals.css
+++ b/packages/example/app/globals.css
@@ -1,26 +1,31 @@
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
+@layer global, base;
+@layer global {
 
-html,
-body {
-  max-width: 100vw;
-  overflow-x: hidden;
-}
-
-body {
-  background: #eee;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
   }
+
+  html,
+  body {
+    max-width: 100vw;
+    overflow-x: hidden;
+  }
+
+  body {
+    background: #eee;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html {
+      color-scheme: dark;
+    }
+  }
+
 }

--- a/packages/example/app/page.tsx
+++ b/packages/example/app/page.tsx
@@ -56,16 +56,18 @@ const Headline = styled.h1<{ $primary?: boolean }>`
 `;
 
 const Button = styled.button<{ $primary?: boolean }>`
-  display: block;
-  ${({ theme }) =>
-    theme.highContrast
-      ? css`
-          color: ${colors.dark};
-        `
-      : css`
-          color: #009688;
-        `}
-  background: #fff;
+  @layer base {
+    display: block;
+    ${({ theme }) =>
+      theme.highContrast
+        ? css`
+            color: ${colors.dark};
+          `
+        : css`
+            color: #009688;
+          `}
+    background: #fff;
+  }
   border: 1px solid currentColor;
   font-size: 17px;
   padding: 7px 12px;


### PR DESCRIPTION
This PR adds examples demonstrating CSS [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) support in next-yak, showcasing how layers can be used to manage style precedence and cascade in a more structured way

- Example: Added `@layer` declarations in global CSS
- Example: Implemented layered styles in a styled component

CSS `@layer` is a powerful addition to CSS that allows developers to explicitly manage the cascade and control specificity. When combined with next-yak, it offers several key benefits:

- Layers provide a way to control specificity without relying on selector specificity or `!important`
- The order of layer declarations determines their precedence, making style overrides more predictable

Example:

```tsx
@layer global, components, theme;

const Button = styled.button`
  @layer components {
    /* Base styles */
    background: white;
  }
  @layer theme {
    /* Theme-specific overrides */
    ${({ theme }) => theme.dark && css`
      background: black;
    `}
  }
`;
```