### PR TITLE
Add the NoInfer to the styled function

### DIFF
--- a/packages/next-yak/runtime/__tests__/typeTest.tsx
+++ b/packages/next-yak/runtime/__tests__/typeTest.tsx
@@ -204,4 +204,29 @@ const CompositionOverridingAndMergingTest = () => {
       </Parent>
     );
   };
+
+  const case4 = () => {
+    const Wrap = styled.button``;
+    const Icon = styled.svg<{ $active: boolean }>``;
+    const Button = styled(Wrap)`
+      ${Icon} {
+        color: red;
+      }
+    `;
+    const Button2 = styled.button`
+      ${Icon} {
+        color: red;
+      }
+    `;
+
+    // @ts-expect-error $active should not be required
+    <Button $active={true}>Click me</Button>;
+
+    // @ts-expect-error $active should not be required
+    <Button2 $active={true}>Click me</Button2>;
+
+    // the types should be equal
+    type Equal = typeof Button extends typeof Button2 ? true : false;
+    const _: Equal = true;
+  };
 };

--- a/packages/next-yak/runtime/__tests__/typeTest.tsx
+++ b/packages/next-yak/runtime/__tests__/typeTest.tsx
@@ -225,6 +225,10 @@ const CompositionOverridingAndMergingTest = () => {
     // @ts-expect-error $active should not be required
     <Button2 $active={true}>Click me</Button2>;
 
+    // should be callable without any properties
+    <Button>Click me</Button>;
+    <Button2>Click me</Button2>;
+
     // the types should be equal
     type Equal = typeof Button extends typeof Button2 ? true : false;
     const _: Equal = true;

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -125,7 +125,9 @@ const yakStyled = <
 
   return <TCSSProps extends object = {}>(
     styles: TemplateStringsArray,
-    ...values: Array<CSSInterpolation<T & TCSSProps & { theme: YakTheme }>>
+    ...values: Array<
+      CSSInterpolation<T & NoInfer<TCSSProps> & { theme: YakTheme }>
+    >
   ) => {
     const getRuntimeStyles = css(styles, ...values);
     const yak = (props: Substitute<TCSSProps & T, TAttrsIn>, ref: unknown) => {


### PR DESCRIPTION
This fixes #180 

When we had the issue previously #104, I fixed it only for the case where the styled proxy was used on native elements. This PR adds the `NoInfer` also to the wrapping API of the styled function.