### PR TITLE
support element switching via `attrs({as: ... })`

### DIFF
--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -214,6 +214,10 @@ const yakStyled = <
         return parentYakComponent(filteredProps as T, ref);
       }
       (filteredProps as { ref?: unknown }).ref = ref;
+      if (typeof Component === "string" && "as" in filteredProps) {
+        const { as: Tag, ...rest } = filteredProps as { as: string };
+        return <Tag {...rest} />;
+      }
       return <Component {...(filteredProps as any)} />;
     };
     return yakForwardRef(yak, mergedAttrsFn);

--- a/packages/next-yak/runtime/styled.tsx
+++ b/packages/next-yak/runtime/styled.tsx
@@ -214,6 +214,7 @@ const yakStyled = <
         return parentYakComponent(filteredProps as T, ref);
       }
       (filteredProps as { ref?: unknown }).ref = ref;
+      // allow to overwrite the html tag with `as`
       if (typeof Component === "string" && "as" in filteredProps) {
         const { as: Tag, ...rest } = filteredProps as { as: string };
         return <Tag {...rest} />;


### PR DESCRIPTION
this PR adds runtime support for switching HTML elements through the `attrs` API:

```ts
const Button = styled.button`/* ... */`
const LinkButton = styled(Button).attrs({ as: 'a' })``
```

@Mad-Kat The runtime code is in place (in `runtime/styled.tsx`). Could you please add TypeScript types to make `as` only available in `attrs` objects but not as a prop on styled components?

fixes #184 