### PR TITLE
fix support for negative numeric constants in cross-file imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:swc": "pnpm run --filter=yak-swc build",
     "watch": "pnpm run --filter=next-yak watch",
     "example": "pnpm --filter=next-yak-example run dev",
-    "test": "pnpm run build && pnpm --filter=next-yak --filter=webpack-tests --filter=next-yak-example run \"/test($|:types)/\"",
+    "test": "pnpm run build && pnpm --filter=next-yak --filter=cross-file-tests --filter=next-yak-example run \"/test($|:types)/\"",
     "test:watch": "pnpm --filter=next-yak run test:watch",
     "test:snapshots": "pnpm --filter=next-yak run test:snapshots",
     "package:types": "npx --package=@arethetypeswrong/cli attw --pack packages/next-yak",

--- a/packages/cross-file-tests/__tests__/fixtures/constant/constants.ts
+++ b/packages/cross-file-tests/__tests__/fixtures/constant/constants.ts
@@ -4,3 +4,5 @@ export const colors = {
     primary: 'var(--color-primary)',
     secondary: 'var(--color-secondary)',
 };
+
+export const negative = -1;

--- a/packages/cross-file-tests/__tests__/fixtures/constant/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/constant/index.tsx
@@ -1,13 +1,13 @@
 import { styled, css } from "next-yak";
-import { colors, siteMaxWidth } from "./constants";
+import { colors, negative, siteMaxWidth } from "./constants";
 export const Button = styled.button<{$variant: 'primary' | 'secondary'}>`
   color: red;
   height: ${siteMaxWidth}px;
   color: ${colors.primary};
   background-color: ${colors.secondary};
+  z-index: ${negative};
   ${({$variant}) => $variant === "secondary" && css`
     color: ${colors.secondary};
     background-color: ${colors.primary};
   `}
-
 `;

--- a/packages/cross-file-tests/__tests__/fixtures/constant/output/constants.ts
+++ b/packages/cross-file-tests/__tests__/fixtures/constant/output/constants.ts
@@ -3,3 +3,4 @@ export var colors = {
     primary: 'var(--color-primary)',
     secondary: 'var(--color-secondary)'
 };
+export var negative = -1;

--- a/packages/cross-file-tests/__tests__/fixtures/constant/output/index.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/constant/output/index.tsx
@@ -1,12 +1,13 @@
 import { styled, css } from "next-yak/internal";
 import __styleYak from "./index.yak.module.css!=!./index?./index.yak.module.css";
-import { colors, siteMaxWidth } from "./constants";
+import { colors, negative, siteMaxWidth } from "./constants";
 export var Button = /*YAK Extracted CSS:
 .Button {
   color: red;
   height: --yak-css-import: url("./constants:siteMaxWidth",mixin)px;
   color: --yak-css-import: url("./constants:colors:primary",mixin);
   background-color: --yak-css-import: url("./constants:colors:secondary",mixin);
+  z-index: --yak-css-import: url("./constants:negative",mixin);
 }
 .Button__ {
   color: --yak-css-import: url("./constants:colors:secondary",mixin);

--- a/packages/cross-file-tests/__tests__/fixtures/constant/output/index.yak.module.css
+++ b/packages/cross-file-tests/__tests__/fixtures/constant/output/index.yak.module.css
@@ -3,6 +3,7 @@
   height: 10px;
   color: var(--color-primary);
   background-color: var(--color-secondary);
+  z-index: -1;
 }
 .Button__ {
   color: var(--color-secondary);

--- a/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/helper/typography.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/helper/typography.tsx
@@ -1,6 +1,6 @@
 import { css } from "next-yak/internal";
 export var typography = {
-    h1: /*YAK EXPORTED MIXIN:typography
+    h1: /*YAK EXPORTED MIXIN:typography:h1
 font-family: "Roboto", sans-serif;
 font-size: 16px;
 font-weight: 400;

--- a/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/mixin.tsx
+++ b/packages/cross-file-tests/__tests__/fixtures/nestedMixin/output/mixin.tsx
@@ -3,7 +3,7 @@ import { Icon } from './icon';
 var buttonTextMixin = /*#__PURE__*/ css();
 export var buttonMixin = /*YAK EXPORTED MIXIN:buttonMixin
 color: black;
---yak-css-import: url("./icon:Icon",mixin) {
+--yak-css-import: url("./icon:Icon",selector) {
   color: black;
 }
 */ /*#__PURE__*/ css();

--- a/packages/cross-file-tests/package.json
+++ b/packages/cross-file-tests/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest --no-watch",
+    "test:snapshots": "UPDATE=1 vitest --no-watch",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/packages/next-yak/loaders/lib/resolveCrossFileSelectors.ts
+++ b/packages/next-yak/loaders/lib/resolveCrossFileSelectors.ts
@@ -431,7 +431,7 @@ function parseExportValueExpression(
     expression.operator === "-" &&
     expression.argument.type === "NumericLiteral"
   ) {
-    return { type: "constant", value: -expression.argument.value }; 
+    return { type: "constant", value: -expression.argument.value };
   } else if (
     expression.type === "TemplateLiteral" &&
     expression.quasis.length === 1
@@ -626,7 +626,7 @@ type ParsedExport =
   | { type: "mixin"; value: string }
   | { type: "constant"; value: string | number }
   | { type: "record"; value: Record<any, ParsedExport> | {} }
-  | { type: "unsupported", hint?: string }
+  | { type: "unsupported"; hint?: string }
   | { type: "re-export"; from: string; imported: string }
   | { type: "star-export"; from: string[] };
 


### PR DESCRIPTION
Add support for negative numeric constants when importing from regular `.ts` files in styled components. Previously, trying to use negative numbers (like `-1`) from `.ts` files would fail during the static extraction phase with an "unexpected exportValue unsupported" error.

While `.yak.ts` files would handle negative numbers correctly through Node evaluation, the static extraction didn't support negative numbers, leading to confusing errors for users

- Added handling for UnaryExpression with negative numbers in the static extraction logic
- Enhanced error reporting by adding value hints when imports fail
- Added test cases for negative values

**Example Usage**
```typescript
// constants.ts
export const negative = -1;

// component.tsx
import { styled } from 'next-yak';
import { negative } from './constants';

export const Button = styled.button`
  z-index: ${negative};
`;
```

fixes #185