### PR TITLE
fix CSS unit handling in nested css`` expressions

### DIFF
--- a/packages/yak-swc/yak_swc/src/utils/add_suffix_to_expr.rs
+++ b/packages/yak-swc/yak_swc/src/utils/add_suffix_to_expr.rs
@@ -3,10 +3,6 @@ use swc_core::{common::DUMMY_SP, ecma::ast::*};
 /// Adds a suffix to an expression
 /// e.g: `({$foo}) => $foo` -> __yak_add_suffix_to_expr(({$foo}) => $foo, "-suffix")
 pub fn add_suffix_to_expr(expr: Expr, helper: Ident, suffix: String) -> Expr {
-  // Try to merge the suffix into the expression
-  if let Some(expr) = merge_suffix_into_expr(suffix.clone(), expr.clone()) {
-    return expr;
-  }
   // Otherwise, replace the expression with a call to the utility function
   Expr::Call(CallExpr {
     span: DUMMY_SP,
@@ -22,42 +18,4 @@ pub fn add_suffix_to_expr(expr: Expr, helper: Ident, suffix: String) -> Expr {
     ],
     type_args: None,
   })
-}
-
-/// Try to merge a suffix right into an expression
-fn merge_suffix_into_expr(suffix: String, expr: Expr) -> Option<Expr> {
-  match &expr {
-    // merge strings e.g. "foo" -> "foo-suffix"
-    Expr::Lit(Lit::Str(str)) => Some(Expr::Lit(Lit::Str(Str {
-      span: DUMMY_SP,
-      value: format!("{}{}", str.value, suffix).into(),
-      raw: None,
-    }))),
-    // merge numbers e.g. 99 -> "99-suffix"
-    Expr::Lit(Lit::Num(num)) => Some(Expr::Lit(Lit::Str(Str {
-      span: DUMMY_SP,
-      value: format!("{}{}", num.value, suffix).into(),
-      raw: None,
-    }))),
-    // merge binary expressions for calculations  e.g. 4 * 3 -> 4 * 3 + "-suffix"
-    Expr::Bin(bin_expr)
-      if matches!(
-        bin_expr.op,
-        BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod
-      ) =>
-    {
-      Some(Expr::Bin(BinExpr {
-        span: DUMMY_SP,
-        left: expr.clone().into(),
-        op: bin_expr.op,
-        right: Box::new(Expr::Lit(Lit::Str(Str {
-          span: DUMMY_SP,
-          value: suffix.into(),
-          raw: None,
-        }))),
-      }))
-    }
-    // Otherwise it has to be replaced at runtime using a utility function
-    _ => None,
-  }
 }

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/input.tsx
@@ -1,4 +1,4 @@
-import { styled } from "next-yak";
+import { styled, css } from "next-yak";
 
 export const FlexContainer = styled.div`
   display: flex;
@@ -9,4 +9,5 @@ export const FlexContainer = styled.div`
   margin-bottom: ${({ $marginBottom }) => $marginBottom || '0'}px;
   top: ${({ $top }) => $top * 20}%;
   background-color: #f0f0f0;
+  ${({ $bottom }) => css`bottom:${$bottom * 20}%`};
 `;

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
@@ -1,4 +1,4 @@
-import { styled, __yak_unitPostFix } from "next-yak/internal";
+import { styled, css, __yak_unitPostFix } from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 export const FlexContainer = /*YAK Extracted CSS:
 .FlexContainer {
@@ -11,7 +11,14 @@ export const FlexContainer = /*YAK Extracted CSS:
   top: var(--FlexContainer__top_o1wkyu);
   background-color: #f0f0f0;
 }
-*/ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, {
+.FlexContainer__ {
+  bottom: var(--FlexContainer__bottom_o1wkyu);
+}
+*/ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
+        "style": {
+            "--FlexContainer__bottom_o1wkyu": $bottom * 20 * "%"
+        }
+    }), {
     "style": {
         "--FlexContainer__align-items_o1wkyu": ({ $align })=>$align || 'stretch',
         "--FlexContainer__flex-direction_o1wkyu": ({ $direction })=>$direction || 'row',

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
@@ -16,7 +16,7 @@ export const FlexContainer = /*YAK Extracted CSS:
 }
 */ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
         "style": {
-            "--FlexContainer__bottom_o1wkyu": $bottom * 20 * "%"
+            "--FlexContainer__bottom_o1wkyu": __yak_unitPostFix($bottom * 20, "%")
         }
     }), {
     "style": {


### PR DESCRIPTION
When using calculations with CSS units inside nested ``` css`` ``` literals, the unit is being multiplied as a string value which breaks the calculation. This only happens in nested ``` css`` ``` expressions, while direct styled-component expressions work correctly

### Working Example (Direct styled-component)
```jsx
import { styled } from "next-yak";

// This works correctly ✅
export const FlexContainer = styled.div`
  top: ${({ $top }) => $top * 20}%;
`;
```

Compiles correctly to:
```jsx
styled.div(__styleYak.FlexContainer, {
  "style": {
    "--FlexContainer__top_o1wkyu": __yak_unitPostFix(({ $top }) => $top * 20, "%")
  }
});
```

### Broken Example (Nested css`` literal)
```jsx
import { styled, css } from "next-yak";

// This breaks ❌
export const FlexContainer = styled.div`
  ${({ $bottom }) => css`bottom: ${$bottom * 20}%`};
`;
```

Compiles incorrectly to:
```jsx
styled.div(__styleYak.FlexContainer, ({ $bottom }) => css(__styleYak.FlexContainer__, {
  "style": {
    "--FlexContainer__bottom_o1wkyu": $bottom * 20 * "%"  // Problem!
  }
}));
```

## Cause
The issue was caused by over-optimization in `add_suffix_to_expr.rs`. The code tried to merge units directly into binary expressions (`4 * 3 -> 4 * 3 + "%"`), which works for simple cases but used the false operator in that case..

Removed the special handling for merging units into expressions entirely. Now all expressions with units consistently use the `__yak_unitPostFix` utility function. This is more robust and handles all cases uniformly, even if slightly less optimized for simple literals

## Testing
Added test case in `props-and-dynamic-styles/input.tsx` to verify the fix works correctly for nested css`` expressions with calculations and units

fixes #188