### PR TITLE
inline negative numbers

### DIFF
--- a/packages/yak-swc/yak_swc/src/math_evaluate.rs
+++ b/packages/yak-swc/yak_swc/src/math_evaluate.rs
@@ -18,6 +18,15 @@ pub fn try_evaluate(expr: &Expr, variable_visitor: &VariableVisitor) -> Option<f
         None
       }
     }
+    // allow expressions like ${-14}
+    Expr::Unary(unary_expr) => {
+      let arg_value = try_evaluate(&unary_expr.arg, variable_visitor)?;
+      match unary_expr.op {
+        UnaryOp::Minus => Some(-arg_value),
+        UnaryOp::Plus => Some(arg_value),
+        _ => None,
+      }
+    }
     Expr::Lit(Lit::Num(num)) => Some(num.value),
     Expr::Bin(bin_expr) => {
       match (&*bin_expr.left, &*bin_expr.right) {

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/input.tsx
@@ -19,6 +19,7 @@ export const Button = styled.button`
   color: ${colors.light};
   padding: 10px ${100 / 3}%;
   z-index: ${stacking};
+  margin-top: ${-1}px;
   border: none;
   border-radius: ${borderRadius};
   cursor: pointer;

--- a/packages/yak-swc/yak_swc/tests/fixture/constants/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/constants/output.tsx
@@ -18,6 +18,7 @@ export const Button = /*YAK Extracted CSS:
   color: #f8f9fa;
   padding: 10px 33.3333%;
   z-index: 1;
+  margin-top: -1px;
   border: none;
   border-radius: 4px;
   cursor: pointer;


### PR DESCRIPTION
currently negative numbers in styled components were being converted to CSS variables and evaluated at runtime, even though they are constant values

This PR fixes this by inlining negative numbers directly into the CSS output

For example:
```tsx
const Button = styled.button`
  margin-top: ${-1}px;
`;
```

Now correctly outputs:
```css
.Button_xyz {
  margin-top: -1px;
}
```

Instead of using CSS variables and runtime evaluation

- Added test case in `constants/input.tsx` to verify negative number inlining
- All existing tests pass

Fixes #191