### PR TITLE
enforce arrow functions

### DIFF
--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -168,6 +168,7 @@ where
     // When moving units into css variables it has to be removed from the next css code
     // e.g. styled.button`left: ${({$x}) => $x}px;` -> `left: var(--left);`
     let mut css_code_offset: usize = 0;
+    let is_top_level = !self.is_inside_css_expression();
 
     let quasis = n.tpl.quasis.clone();
 
@@ -385,6 +386,11 @@ where
           // If the expression is inside a css property value
           // it has to be replaced with a css variable
           if is_inside_property_value {
+            // Show an error if the expression is not valid
+            // e.g. styled.button`left: ${getPosition()}px;`
+            if is_top_level {
+              verify_valid_property_value_expr(expr);
+            }
             // Check if the next quasi starts with a unit
             // e.g. styled.button`left: ${({$x}) => $x}px;`
             let unit = if let Some(next_quasi) = pair.next_quasi {
@@ -852,6 +858,30 @@ fn extract_leading_css_unit(css: &str) -> Option<&str> {
     return Some(unit);
   }
   None
+}
+
+/// Validates expressions used in CSS property values.
+/// Currently only allows arrow functions for dynamic values to make runtime behavior explicit.
+fn verify_valid_property_value_expr(expr: &Expr) -> bool {
+  match expr {
+    // Allow arrow functions - this is the preferred format
+    // e.g. styled.button`left: ${({$x}) => $x}px;`
+    Expr::Arrow(_) => true,
+
+    // For all other expression types, show an error explaining the requirement
+    _ => {
+      HANDLER.with(|handler| {
+              handler
+                  .struct_span_err(
+                      expr.span(),
+                      "Dynamic values in CSS properties must be wrapped in arrow functions to make runtime behavior explicit.\n\
+                       Example: ${() => getValue()} instead of ${getValue()}"
+                  )
+                  .emit();
+          });
+      false
+    }
+  }
 }
 
 #[plugin_transform]

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/input.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/input.tsx
@@ -1,0 +1,7 @@
+import { styled } from "next-yak";
+
+export const FlexContainer = styled.div`
+  display: flex;
+  z-index: ${getZIndex()};
+  margin-bottom: ${spacing[40].toString()}px;
+`;

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.stderr
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.stderr
@@ -1,0 +1,16 @@
+  x Dynamic values in CSS properties must be wrapped in arrow functions to make runtime behavior explicit.
+  | Example: ${() => getValue()} instead of ${getValue()}
+   ,-[input.js:5:1]
+ 4 |   display: flex;
+ 5 |   z-index: ${getZIndex()};
+   :              ^^^^^^^^^^^
+ 6 |   margin-bottom: ${spacing[40].toString()}px;
+   `----
+  x Dynamic values in CSS properties must be wrapped in arrow functions to make runtime behavior explicit.
+  | Example: ${() => getValue()} instead of ${getValue()}
+   ,-[input.js:6:1]
+ 5 |   z-index: ${getZIndex()};
+ 6 |   margin-bottom: ${spacing[40].toString()}px;
+   :                    ^^^^^^^^^^^^^^^^^^^^^^
+ 7 | `;
+   `----

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.tsx
@@ -1,0 +1,14 @@
+import { styled, __yak_unitPostFix } from "next-yak/internal";
+import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
+export const FlexContainer = /*YAK Extracted CSS:
+.FlexContainer {
+  display: flex;
+  z-index: var(--FlexContainer__z-index_o1wkyu);
+  margin-bottom: var(--FlexContainer__margin-bottom_o1wkyu);
+}
+*/ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, {
+    "style": {
+        "--FlexContainer__margin-bottom_o1wkyu": __yak_unitPostFix(spacing[40].toString(), "px"),
+        "--FlexContainer__z-index_o1wkyu": getZIndex()
+    }
+});


### PR DESCRIPTION
when migrating from styled-components, users often write dynamic values in CSS properties without realizing they'll be executed at runtime:

```javascript
import { styled } from "next-yak";
const Button = styled.button`
   z-index: ${getZIndex()}
`
```

while this works (next-yak handles it by using CSS variables and inline styles), the runtime behavior isn't immediately obvious to users. 

This behaviour can lead to confusion about what gets extracted at build time versus what runs in the browser

Therefore this PR enforces the use of arrow functions for dynamic property values in top-level styled components. This makes the runtime nature of these values explicit in the syntax:

```javascript
import { styled } from "next-yak";
const Button = styled.button`
   z-index: ${() => getZIndex()}
`
```

The compiler will now emit an error for direct function calls or expressions in property values, requiring them to be wrapped in arrow functions.

Important notes:
- This only affects property values (like `z-index`, `color`, etc)
- Only enforced at the top level - nested expressions within css`` template literals are not affected
- Still allows constants and other static values

For example, this remains valid:
```tsx
import { styled, css } from "next-yak";
const Button = styled.button`
   ${({$x}) => 
      $x > 0 && css`left: ${$x}px`
   }
`
```

#### Benefits

- Makes runtime behavior obvious in the code
- Provides clear mental model: `arrow function -> runtime value & CSS variable`

#### Breaking Change

This is a breaking change for users who directly call functions or use expressions in CSS property values. They'll need to wrap these in arrow functions:

Before:
```js
styled.button`
  width: ${getWidth()}px;
  color: ${theme.color};
`
```

After:
```js
styled.button`
  width: ${() => getWidth()}px;
  color: ${() => theme.color};
`
```

#### Testing

Added test case `dynamic-prop-error`

fixes #187