### PR TITLE
Switch to FNV-1a hash for CSS identifiers

### DIFF
--- a/.changeset/early-falcons-clap.md
+++ b/.changeset/early-falcons-clap.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": minor
+---
+
+Improved CSS class name generation using FNV-1a hashing for better cross-platform consistency and shorter identifiers

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,27 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-changeset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check for changeset
+        run: npx changeset status --since=origin/main
+   

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -19,8 +19,11 @@ jobs:
         with:
           node-version: '20.x'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.6.1
+          run_install: true
 
       - name: Check for changeset
         run: npx changeset status --since=origin/main

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -72,6 +72,3 @@ jobs:
 
       - name: Test
         run: pnpm run test
-
-      - name: Changeset Check
-        run: pnpm changeset status --since=main

--- a/packages/example/app/__tests__/__snapshots__/Clock.test.tsx.snap
+++ b/packages/example/app/__tests__/__snapshots__/Clock.test.tsx.snap
@@ -14,98 +14,98 @@ exports[`renders Clock component 1`] = `
       <div
         class="ClockNumber"
         index="0"
-        style="--ClockNumber__transform_15c3sj0: 0deg; --ClockNumber__transform_15c3sj0-01: 0deg;"
+        style="--ClockNumber__transform_EiiKjd: 0deg; --ClockNumber__transform_EiiKjd-01: 0deg;"
       >
         12
       </div>
       <div
         class="ClockNumber"
         index="1"
-        style="--ClockNumber__transform_15c3sj0: 30deg; --ClockNumber__transform_15c3sj0-01: -30deg;"
+        style="--ClockNumber__transform_EiiKjd: 30deg; --ClockNumber__transform_EiiKjd-01: -30deg;"
       >
         1
       </div>
       <div
         class="ClockNumber"
         index="2"
-        style="--ClockNumber__transform_15c3sj0: 60deg; --ClockNumber__transform_15c3sj0-01: -60deg;"
+        style="--ClockNumber__transform_EiiKjd: 60deg; --ClockNumber__transform_EiiKjd-01: -60deg;"
       >
         2
       </div>
       <div
         class="ClockNumber"
         index="3"
-        style="--ClockNumber__transform_15c3sj0: 90deg; --ClockNumber__transform_15c3sj0-01: -90deg;"
+        style="--ClockNumber__transform_EiiKjd: 90deg; --ClockNumber__transform_EiiKjd-01: -90deg;"
       >
         3
       </div>
       <div
         class="ClockNumber"
         index="4"
-        style="--ClockNumber__transform_15c3sj0: 120deg; --ClockNumber__transform_15c3sj0-01: -120deg;"
+        style="--ClockNumber__transform_EiiKjd: 120deg; --ClockNumber__transform_EiiKjd-01: -120deg;"
       >
         4
       </div>
       <div
         class="ClockNumber"
         index="5"
-        style="--ClockNumber__transform_15c3sj0: 150deg; --ClockNumber__transform_15c3sj0-01: -150deg;"
+        style="--ClockNumber__transform_EiiKjd: 150deg; --ClockNumber__transform_EiiKjd-01: -150deg;"
       >
         5
       </div>
       <div
         class="ClockNumber"
         index="6"
-        style="--ClockNumber__transform_15c3sj0: 180deg; --ClockNumber__transform_15c3sj0-01: -180deg;"
+        style="--ClockNumber__transform_EiiKjd: 180deg; --ClockNumber__transform_EiiKjd-01: -180deg;"
       >
         6
       </div>
       <div
         class="ClockNumber"
         index="7"
-        style="--ClockNumber__transform_15c3sj0: 210deg; --ClockNumber__transform_15c3sj0-01: -210deg;"
+        style="--ClockNumber__transform_EiiKjd: 210deg; --ClockNumber__transform_EiiKjd-01: -210deg;"
       >
         7
       </div>
       <div
         class="ClockNumber"
         index="8"
-        style="--ClockNumber__transform_15c3sj0: 240deg; --ClockNumber__transform_15c3sj0-01: -240deg;"
+        style="--ClockNumber__transform_EiiKjd: 240deg; --ClockNumber__transform_EiiKjd-01: -240deg;"
       >
         8
       </div>
       <div
         class="ClockNumber"
         index="9"
-        style="--ClockNumber__transform_15c3sj0: 270deg; --ClockNumber__transform_15c3sj0-01: -270deg;"
+        style="--ClockNumber__transform_EiiKjd: 270deg; --ClockNumber__transform_EiiKjd-01: -270deg;"
       >
         9
       </div>
       <div
         class="ClockNumber"
         index="10"
-        style="--ClockNumber__transform_15c3sj0: 300deg; --ClockNumber__transform_15c3sj0-01: -300deg;"
+        style="--ClockNumber__transform_EiiKjd: 300deg; --ClockNumber__transform_EiiKjd-01: -300deg;"
       >
         10
       </div>
       <div
         class="ClockNumber"
         index="11"
-        style="--ClockNumber__transform_15c3sj0: 330deg; --ClockNumber__transform_15c3sj0-01: -330deg;"
+        style="--ClockNumber__transform_EiiKjd: 330deg; --ClockNumber__transform_EiiKjd-01: -330deg;"
       >
         11
       </div>
       <div
         class="SecondHand SecondHand__theme_highContrast-01 ClockHand"
-        style="--ClockHand__transform_4acxch: 0deg;"
+        style="--ClockHand__transform_cN6khQ: 0deg;"
       />
       <div
         class="MinuteHand ClockHand"
-        style="--ClockHand__transform_4acxch: 0deg;"
+        style="--ClockHand__transform_cN6khQ: 0deg;"
       />
       <div
         class="HourHand ClockHand"
-        style="--ClockHand__transform_4acxch: 450deg;"
+        style="--ClockHand__transform_cN6khQ: 450deg;"
       />
     </div>
   </div>

--- a/packages/example/app/__tests__/__snapshots__/ClockHands.test.tsx.snap
+++ b/packages/example/app/__tests__/__snapshots__/ClockHands.test.tsx.snap
@@ -4,15 +4,15 @@ exports[`renders ClockHands component 1`] = `
 <DocumentFragment>
   <div
     class="SecondHand SecondHand__theme_highContrast-01 ClockHand"
-    style="--ClockHand__transform_4acxch: 0deg;"
+    style="--ClockHand__transform_cN6khQ: 0deg;"
   />
   <div
     class="MinuteHand ClockHand"
-    style="--ClockHand__transform_4acxch: 0deg;"
+    style="--ClockHand__transform_cN6khQ: 0deg;"
   />
   <div
     class="HourHand ClockHand"
-    style="--ClockHand__transform_4acxch: 450deg;"
+    style="--ClockHand__transform_cN6khQ: 450deg;"
   />
 </DocumentFragment>
 `;

--- a/packages/yak-swc/yak_swc/src/naming_convention.rs
+++ b/packages/yak-swc/yak_swc/src/naming_convention.rs
@@ -151,16 +151,16 @@ mod tests {
   #[test]
   fn css_variable_name() {
     let mut convention = NamingConvention::new("file.css".into(), false);
-    assert_eq!(convention.get_css_variable_name("foo"), "yupb5bt");
-    assert_eq!(convention.get_css_variable_name("foo"), "yupb5bt1");
-    assert_eq!(convention.get_css_variable_name(""), "yupb5bt2");
+    assert_eq!(convention.get_css_variable_name("foo"), "yoPBkbU");
+    assert_eq!(convention.get_css_variable_name("foo"), "yoPBkbU1");
+    assert_eq!(convention.get_css_variable_name(""), "yoPBkbU2");
   }
 
   #[test]
   fn css_variable_name_dev_mode() {
     let mut convention = NamingConvention::new("file.css".into(), true);
-    assert_eq!(convention.get_css_variable_name("foo"), "foo_upb5bt");
-    assert_eq!(convention.get_css_variable_name("foo"), "foo_upb5bt-01");
-    assert_eq!(convention.get_css_variable_name(""), "yak_upb5bt");
+    assert_eq!(convention.get_css_variable_name("foo"), "foo_oPBkbU");
+    assert_eq!(convention.get_css_variable_name("foo"), "foo_oPBkbU-01");
+    assert_eq!(convention.get_css_variable_name(""), "yak_oPBkbU");
   }
 }

--- a/packages/yak-swc/yak_swc/src/utils/css_hash.rs
+++ b/packages/yak-swc/yak_swc/src/utils/css_hash.rs
@@ -1,14 +1,26 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
+/// Implementation of the FNV-1a (Fowler-Noll-Vo) hash algorithm for CSS identifiers
+/// This is a non-cryptographic hash function that is:
+/// - Fast and simple
+/// - Deterministic across platforms
+/// - Good distribution for short strings
+const FNV_PRIME: u64 = 1099511628211;
+const FNV_OFFSET_BASIS: u64 = 14695981039346656037;
 
-/// Creates a CSS-compatible identifier using Rust's DefaultHasher (SipHash-1-3)
-///
-/// Takes an ASCII string and returns a base62 encoded hash result
-/// that is a valid CSS identifier starting with a letter
+/// Creates a CSS-compatible identifier using FNV-1a hash
+/// Returns a base62 encoded hash result that is a valid CSS identifier
 pub fn hash_to_css(input: &str) -> String {
-  let mut hasher = DefaultHasher::new();
-  input.hash(&mut hasher);
-  let hash = hasher.finish();
+  let hash = fnv1a_64(input);
   to_css_identifier(hash)
+}
+
+/// FNV-1a 64-bit hash implementation
+fn fnv1a_64(input: &str) -> u64 {
+  let mut hash = FNV_OFFSET_BASIS;
+  for byte in input.bytes() {
+    hash ^= u64::from(byte);
+    hash = hash.wrapping_mul(FNV_PRIME);
+  }
+  hash
 }
 
 // Helper function to convert u64 to a valid CSS identifier
@@ -47,24 +59,24 @@ mod tests {
 
   #[test]
   fn test_empty_string() {
-    assert_eq!(hash_to_css(""), "hQ4kcJ");
+    assert_eq!(hash_to_css(""), "brmrUI");
   }
 
   #[test]
   fn test_short_string() {
-    assert_eq!(hash_to_css("special/path/page.tsx"), "Uy8NrL");
+    assert_eq!(hash_to_css("special/path/page.tsx"), "TzYwQZ");
   }
 
   #[test]
   fn test_medium_string() {
-    assert_eq!(hash_to_css("hello"), "H6oyDl");
+    assert_eq!(hash_to_css("hello"), "RMT3qV");
   }
 
   #[test]
   fn test_long_string() {
     assert_eq!(
       hash_to_css("The quick brown fox jumps over the lazy dog"),
-      "zqke8J"
+      "OkGoM1"
     );
   }
 

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin-nested/output.tsx
@@ -2,11 +2,11 @@ import { styled, css, __yak_unitPostFix } from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const buttonStyles = /*#__PURE__*/ css(({ $active })=>$active && /*#__PURE__*/ css(__styleYak.buttonStyles__$active, {
         "style": {
-            "--buttonStyles__max-width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--buttonStyles__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--buttonStyles__width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--buttonStyles__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const ThemedButton = /*YAK Extracted CSS:
@@ -19,19 +19,19 @@ export const ThemedButton = /*YAK Extracted CSS:
 .ThemedButton__$active {
   @media (max-width: 600px) {
     background-color: #f0f0f0;
-    max-width: var(--ThemedButton__max-width_pMS1gk);
+    max-width: var(--ThemedButton__max-width_m7uBBu);
   }
 }
 .ThemedButton {
-  width: var(--ThemedButton__width_pMS1gk);
+  width: var(--ThemedButton__width_m7uBBu);
 }
 */ /*#__PURE__*/ styled.button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
-            "--ThemedButton__max-width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--ThemedButton__width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
@@ -48,21 +48,21 @@ export const CustomThemedButton = /*YAK Extracted CSS:
   &:not([disabled]) {
     @media (max-width: 600px) {
       background-color: #f0f0f0;
-      max-width: var(--CustomThemedButton__max-width_pMS1gk);
+      max-width: var(--CustomThemedButton__max-width_m7uBBu);
     }
   }
 }
 .CustomThemedButton {
   &:not([disabled]) {
-    width: var(--CustomThemedButton__width_pMS1gk);
+    width: var(--CustomThemedButton__width_m7uBBu);
   }
 }
 */ /*#__PURE__*/ styled.button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
-            "--CustomThemedButton__max-width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--CustomThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), {
     "style": {
-        "--CustomThemedButton__width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--CustomThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/css-mixin/output.tsx
@@ -2,13 +2,13 @@ import { styled, css, __yak_unitPostFix } from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const buttonStyles = /*#__PURE__*/ css(({ $active })=>$active && /*#__PURE__*/ css(__styleYak.buttonStyles__$active, {
         "style": {
-            "--buttonStyles__max-width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--buttonStyles__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.buttonStyles__);
 }, {
     "style": {
-        "--buttonStyles__width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--buttonStyles__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const ThemedButton = /*YAK Extracted CSS:
@@ -20,23 +20,23 @@ export const ThemedButton = /*YAK Extracted CSS:
 }
 .ThemedButton__$active {
   background-color: #f0f0f0;
-  max-width: var(--ThemedButton__max-width_pMS1gk);
+  max-width: var(--ThemedButton__max-width_m7uBBu);
 }
 .ThemedButton {
-  width: var(--ThemedButton__width_pMS1gk);
+  width: var(--ThemedButton__width_m7uBBu);
 }
 .ThemedButton__ {
   color: red;
 }
 */ /*#__PURE__*/ styled.button(__styleYak.ThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.ThemedButton__$active, {
         "style": {
-            "--ThemedButton__max-width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--ThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.ThemedButton__);
 }, {
     "style": {
-        "--ThemedButton__width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--ThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });
 export const CustomThemedButton = /*YAK Extracted CSS:
@@ -49,22 +49,22 @@ export const CustomThemedButton = /*YAK Extracted CSS:
 }
 .CustomThemedButton__$active {
   background-color: #f0f0f0;
-  max-width: var(--CustomThemedButton__max-width_pMS1gk);
+  max-width: var(--CustomThemedButton__max-width_m7uBBu);
 }
 .CustomThemedButton {
-  width: var(--CustomThemedButton__width_pMS1gk);
+  width: var(--CustomThemedButton__width_m7uBBu);
 }
 .CustomThemedButton__ {
   color: red;
 }
 */ /*#__PURE__*/ styled.button(__styleYak.CustomThemedButton, ({ $active })=>$active && /*#__PURE__*/ css(__styleYak.CustomThemedButton__$active, {
         "style": {
-            "--CustomThemedButton__max-width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
+            "--CustomThemedButton__max-width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 15, "px")
         }
     }), function({ $letters }) {
     return $letters > 5 && /*#__PURE__*/ css(__styleYak.CustomThemedButton__);
 }, {
     "style": {
-        "--CustomThemedButton__width_pMS1gk": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
+        "--CustomThemedButton__width_m7uBBu": __yak_unitPostFix(({ $letters })=>$letters * 10, "px")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/dynamic-prop-error/output.tsx
@@ -3,12 +3,12 @@ import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css"
 export const FlexContainer = /*YAK Extracted CSS:
 .FlexContainer {
   display: flex;
-  z-index: var(--FlexContainer__z-index_pMS1gk);
-  margin-bottom: var(--FlexContainer__margin-bottom_pMS1gk);
+  z-index: var(--FlexContainer__z-index_m7uBBu);
+  margin-bottom: var(--FlexContainer__margin-bottom_m7uBBu);
 }
 */ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, {
     "style": {
-        "--FlexContainer__margin-bottom_pMS1gk": __yak_unitPostFix(spacing[40].toString(), "px"),
-        "--FlexContainer__z-index_pMS1gk": getZIndex()
+        "--FlexContainer__margin-bottom_m7uBBu": __yak_unitPostFix(spacing[40].toString(), "px"),
+        "--FlexContainer__z-index_m7uBBu": getZIndex()
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/props-and-dynamic-styles/output.tsx
@@ -3,27 +3,27 @@ import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css"
 export const FlexContainer = /*YAK Extracted CSS:
 .FlexContainer {
   display: flex;
-  align-items: var(--FlexContainer__align-items_pMS1gk);
-  flex-direction: var(--FlexContainer__flex-direction_pMS1gk);
-  justify-content: var(--FlexContainer__justify-content_pMS1gk);
+  align-items: var(--FlexContainer__align-items_m7uBBu);
+  flex-direction: var(--FlexContainer__flex-direction_m7uBBu);
+  justify-content: var(--FlexContainer__justify-content_m7uBBu);
   padding: 20px;
-  margin-bottom: var(--FlexContainer__margin-bottom_pMS1gk);
-  top: var(--FlexContainer__top_pMS1gk);
+  margin-bottom: var(--FlexContainer__margin-bottom_m7uBBu);
+  top: var(--FlexContainer__top_m7uBBu);
   background-color: #f0f0f0;
 }
 .FlexContainer__ {
-  bottom: var(--FlexContainer__bottom_pMS1gk);
+  bottom: var(--FlexContainer__bottom_m7uBBu);
 }
 */ /*#__PURE__*/ styled.div(__styleYak.FlexContainer, ({ $bottom })=>/*#__PURE__*/ css(__styleYak.FlexContainer__, {
         "style": {
-            "--FlexContainer__bottom_pMS1gk": __yak_unitPostFix($bottom * 20, "%")
+            "--FlexContainer__bottom_m7uBBu": __yak_unitPostFix($bottom * 20, "%")
         }
     }), {
     "style": {
-        "--FlexContainer__align-items_pMS1gk": ({ $align })=>$align || 'stretch',
-        "--FlexContainer__flex-direction_pMS1gk": ({ $direction })=>$direction || 'row',
-        "--FlexContainer__justify-content_pMS1gk": ({ $justify })=>$justify || 'flex-start',
-        "--FlexContainer__margin-bottom_pMS1gk": __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
-        "--FlexContainer__top_pMS1gk": __yak_unitPostFix(({ $top })=>$top * 20, "%")
+        "--FlexContainer__align-items_m7uBBu": ({ $align })=>$align || 'stretch',
+        "--FlexContainer__flex-direction_m7uBBu": ({ $direction })=>$direction || 'row',
+        "--FlexContainer__justify-content_m7uBBu": ({ $justify })=>$justify || 'flex-start',
+        "--FlexContainer__margin-bottom_m7uBBu": __yak_unitPostFix(({ $marginBottom })=>$marginBottom || '0', "px"),
+        "--FlexContainer__top_m7uBBu": __yak_unitPostFix(({ $top })=>$top * 20, "%")
     }
 });

--- a/packages/yak-swc/yak_swc/tests/fixture/theming-with-context/output.tsx
+++ b/packages/yak-swc/yak_swc/tests/fixture/theming-with-context/output.tsx
@@ -3,14 +3,14 @@ import { styled } from "next-yak/internal";
 import __styleYak from "./input.yak.module.css!=!./input?./input.yak.module.css";
 const ThemedComponent = /*YAK Extracted CSS:
 .ThemedComponent {
-  background-color: var(--ThemedComponent__background-color_pMS1gk);
-  color: var(--ThemedComponent__color_pMS1gk);
+  background-color: var(--ThemedComponent__background-color_m7uBBu);
+  color: var(--ThemedComponent__color_m7uBBu);
   padding: 20px;
   border-radius: 8px;
 }
 */ /*#__PURE__*/ styled.div(__styleYak.ThemedComponent, {
     "style": {
-        "--ThemedComponent__background-color_pMS1gk": (props)=>props.theme.background,
-        "--ThemedComponent__color_pMS1gk": (props)=>props.theme.text
+        "--ThemedComponent__background-color_m7uBBu": (props)=>props.theme.background,
+        "--ThemedComponent__color_m7uBBu": (props)=>props.theme.text
     }
 });


### PR DESCRIPTION
This PR replaces our current CSS identifier hashing implementation with FNV-1a (Fowler-Noll-Vo), a fast and platform-independent hash function that is better suited for generating CSS identifiers.

## Changes

- Replace custom hash implementation with FNV-1a algorithm
- Improve CSS identifier generation to ensure valid CSS class names
- Update tests with deterministic hash values
- Update snapshots to reflect new hash output format

## Why FNV-1a?

The FNV-1a hash algorithm is an ideal choice for this use case because:

1. **Deterministic Output**: Guarantees consistent hashes across:
   - Different operating systems (Windows/Mac/Linux)
   - Different architectures (x86/ARM/WASM)
   - Different builds and process executions

2. **Performance**: FNV-1a is:
   - Simple and fast (uses basic bitwise operations)
   - Memory efficient (operates on bytes directly)
   - Well-suited for short strings like class names

3. **Distribution**: Provides excellent distribution characteristics for:
   - Short strings (like component names)
   - Similar strings (like nested selectors)
   - Small changes in input

## CSS Identifier Format

The new hash format:
```diff
- y_17k2ec6  // old format
+ ymdkqtp     // new format
```

Changes to identifier generation:
- Always starts with a lowercase letter (CSS requirement)
- Uses 6 characters for consistent length
- Utilizes base62 encoding (a-z, A-Z, 0-9) for maximum readability
- Maintains uniqueness while being shorter