### PR TITLE
allow to define the prefix for generated names

### DIFF
--- a/.changeset/silver-hairs-clean.md
+++ b/.changeset/silver-hairs-clean.md
@@ -1,0 +1,5 @@
+---
+"yak-swc": minor
+---
+
+allow to define the prefix for generated names

--- a/packages/yak-swc/yak_swc/src/lib.rs
+++ b/packages/yak-swc/yak_swc/src/lib.rs
@@ -56,6 +56,8 @@ pub struct Config {
   /// To ensure that the hash is consistent accross multiple systems the relative path
   /// from the base dir to the source file is used.
   pub base_path: String,
+  /// Prefix for the generated css identifier
+  pub prefix: Option<String>,
 }
 
 pub struct TransformVisitor<GenericComments>
@@ -106,7 +108,12 @@ impl<GenericComments> TransformVisitor<GenericComments>
 where
   GenericComments: Comments,
 {
-  pub fn new(comments: Option<GenericComments>, filename: String, dev_mode: bool) -> Self {
+  pub fn new(
+    comments: Option<GenericComments>,
+    filename: String,
+    dev_mode: bool,
+    prefix: Option<String>,
+  ) -> Self {
     Self {
       current_css_state: None,
       current_declaration: vec![],
@@ -115,7 +122,7 @@ where
       current_exported: false,
       variables: VariableVisitor::new(),
       yak_library_imports: YakImportVisitor::new(),
-      naming_convention: NamingConvention::new(filename.clone(), dev_mode),
+      naming_convention: NamingConvention::new(filename.clone(), dev_mode, prefix),
       variable_name_selector_mapping: FxHashMap::default(),
       expression_replacement: None,
       css_module_identifier: None,
@@ -959,6 +966,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     metadata.comments,
     deterministic_path,
     config.dev_mode,
+    config.prefix,
   )))
 }
 
@@ -997,6 +1005,7 @@ mod tests {
           Some(tester.comments.clone()),
           "path/input.tsx".to_string(),
           true,
+          None,
         ))
       },
       &input,


### PR DESCRIPTION
I've added support for configuring the prefix used by next-yak for generated CSS classes and variables  
This can help in identifying yak-generated classes in tests or to avoid collisions with other libraries

The default prefix remains `y` in production and empty in dev mode, so this is fully backwards compatible

If needed you can now configure a custom prefix:

```js
// next.config.js
export default withYak({
  prefix: 'my-app-'
});
```

The patch also adjusts the dev mode variable prefix from 'yak_' to 'var_' which makes a bit more sense semantically